### PR TITLE
Add better events

### DIFF
--- a/src/ack/mod.rs
+++ b/src/ack/mod.rs
@@ -1,149 +1,149 @@
 pub mod queue;
-use std::io::{Cursor, Read, Write};
 use binary_utils::*;
-use byteorder::{BE, ReadBytesExt, WriteBytesExt};
+use byteorder::{ReadBytesExt, WriteBytesExt, BE};
+use std::io::Cursor;
 
 #[derive(Debug, Clone)]
 pub enum Record {
-     Single(SingleRecord),
-     Range(RangeRecord),
+    Single(SingleRecord),
+    Range(RangeRecord),
 }
 
 impl Record {
-     pub fn is_single(&self) -> bool {
-          match *self {
-               Self::Range(_) => false,
-               Self::Single(_) => true,
-          }
-     }
+    pub fn is_single(&self) -> bool {
+        match *self {
+            Self::Range(_) => false,
+            Self::Single(_) => true,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct SingleRecord {
-     pub sequence: u32,
+    pub sequence: u32,
 }
 
 #[derive(Debug, Clone)]
 pub struct RangeRecord {
-     pub start: u32,
-     pub end: u32,
+    pub start: u32,
+    pub end: u32,
 }
 
 impl RangeRecord {
-     /// Gets the sequences in the range of [start, end).
-     pub fn get_sequences(&self) -> Vec<u32> {
-          let mut seqs = vec![];
-          let highest = if self.end > self.start {
-               self.end
-          } else {
-               self.start
-          };
-          let lowest = if self.end > self.start {
-               self.start
-          } else {
-               self.end
-          };
-          for i in lowest..highest {
-               seqs.push(i);
-          }
-          seqs
-     }
+    /// Gets the sequences in the range of [start, end).
+    pub fn get_sequences(&self) -> Vec<u32> {
+        let mut seqs = vec![];
+        let highest = if self.end > self.start {
+            self.end
+        } else {
+            self.start
+        };
+        let lowest = if self.end > self.start {
+            self.start
+        } else {
+            self.end
+        };
+        for i in lowest..highest {
+            seqs.push(i);
+        }
+        seqs
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct Ack {
-     pub count: u16,
-     pub records: Vec<Record>,
-     pub id: AckIds,
+    pub count: u16,
+    pub records: Vec<Record>,
+    pub id: AckIds,
 }
 
 impl Ack {
-     pub fn new(count: u16, nack: bool) -> Self {
-          Self {
-               count,
-               records: Vec::new(),
-               id: match nack {
-                    true => AckIds::Acknowledge,
-                    false => AckIds::NoAcknowledge,
-               },
-          }
-     }
+    pub fn new(count: u16, nack: bool) -> Self {
+        Self {
+            count,
+            records: Vec::new(),
+            id: match nack {
+                true => AckIds::Acknowledge,
+                false => AckIds::NoAcknowledge,
+            },
+        }
+    }
 }
 
 impl Streamable for Ack {
-     fn compose(source: &[u8], position: &mut usize) -> Self {
-          let mut stream = Cursor::new(source);
-          let id = stream.read_u8().unwrap();
-          let count = stream.read_u16::<BE>().unwrap();
-          let mut records: Vec<Record> = Vec::new();
-          for _ in 0..count {
-               if stream.read_u8().unwrap() == 1 {
-                    let record: SingleRecord = SingleRecord {
-                         sequence: stream.read_u24::<BE>().unwrap(),
-                    };
+    fn compose(source: &[u8], _position: &mut usize) -> Self {
+        let mut stream = Cursor::new(source);
+        let id = stream.read_u8().unwrap();
+        let count = stream.read_u16::<BE>().unwrap();
+        let mut records: Vec<Record> = Vec::new();
+        for _ in 0..count {
+            if stream.read_u8().unwrap() == 1 {
+                let record: SingleRecord = SingleRecord {
+                    sequence: stream.read_u24::<BE>().unwrap(),
+                };
 
-                    records.push(Record::Single(record));
-               } else {
-                    let record: RangeRecord = RangeRecord {
-                         start: stream.read_u24::<BE>().unwrap(),
-                         end: stream.read_u24::<BE>().unwrap(),
-                    };
+                records.push(Record::Single(record));
+            } else {
+                let record: RangeRecord = RangeRecord {
+                    start: stream.read_u24::<BE>().unwrap(),
+                    end: stream.read_u24::<BE>().unwrap(),
+                };
 
-                    records.push(Record::Range(record));
-               }
-          }
+                records.push(Record::Range(record));
+            }
+        }
 
-          Self {
-               count,
-               records,
-               id: AckIds::from_byte(id),
-          }
-     }
+        Self {
+            count,
+            records,
+            id: AckIds::from_byte(id),
+        }
+    }
 
-     fn parse(&self) -> Vec<u8> {
-          let mut stream = Vec::<u8>::new();
-          stream.write_u8(AckIds::Acknowledge as u8).unwrap();
-          stream.write_u16::<BE>(self.count).unwrap();
+    fn parse(&self) -> Vec<u8> {
+        let mut stream = Vec::<u8>::new();
+        stream.write_u8(AckIds::Acknowledge as u8).unwrap();
+        stream.write_u16::<BE>(self.count).unwrap();
 
-          for record in self.records.iter() {
-               match record {
-                    Record::Single(rec) => {
-                         stream.write_u8(1).unwrap();
-                         stream.write_u24::<BE>(rec.sequence).unwrap();
-                    }
-                    Record::Range(rec) => {
-                         stream.write_u8(0).unwrap();
-                         stream.write_u24::<BE>(rec.start).unwrap();
-                         stream.write_u24::<BE>(rec.end).unwrap();
-                    }
-               }
-          }
-          stream
-     }
+        for record in self.records.iter() {
+            match record {
+                Record::Single(rec) => {
+                    stream.write_u8(1).unwrap();
+                    stream.write_u24::<BE>(rec.sequence).unwrap();
+                }
+                Record::Range(rec) => {
+                    stream.write_u8(0).unwrap();
+                    stream.write_u24::<BE>(rec.start).unwrap();
+                    stream.write_u24::<BE>(rec.end).unwrap();
+                }
+            }
+        }
+        stream
+    }
 }
 
 #[derive(Debug, Clone)]
 pub enum AckIds {
-     Acknowledge = 0xc0,
-     NoAcknowledge = 0xa0,
+    Acknowledge = 0xc0,
+    NoAcknowledge = 0xa0,
 }
 
 impl AckIds {
-     pub fn from_byte(byte: u8) -> Self {
-          match byte {
-               0xa0 => Self::NoAcknowledge,
-               _ => Self::Acknowledge,
-          }
-     }
+    pub fn from_byte(byte: u8) -> Self {
+        match byte {
+            0xa0 => Self::NoAcknowledge,
+            _ => Self::Acknowledge,
+        }
+    }
 
-     pub fn to_byte(&self) -> u8 {
-          match *self {
-               Self::Acknowledge => 0xc0,
-               Self::NoAcknowledge => 0xa0,
-          }
-     }
+    pub fn to_byte(&self) -> u8 {
+        match *self {
+            Self::Acknowledge => 0xc0,
+            Self::NoAcknowledge => 0xa0,
+        }
+    }
 }
 
 pub fn is_ack_or_nack(byte: u8) -> bool {
-     byte == 0xa0 || byte == 0xc0
+    byte == 0xa0 || byte == 0xc0
 }

--- a/src/ack/processor.rs
+++ b/src/ack/processor.rs
@@ -2,15 +2,15 @@ use super::queue::{AckQueue, NAckQueue};
 // Processes ack packets for the server.
 
 pub struct AckProcessor {
-     ack_queue: AckQueue,
-     nack_queue: NAckQueue,
+    ack_queue: AckQueue,
+    nack_queue: NAckQueue,
 }
 
 impl AckProcessor {
-     pub fn new() -> Self {
-          Self {
-               ack_queue: AckQueue::new(),
-               nack_queue: NAckQueue::new(),
-          }
-     }
+    pub fn new() -> Self {
+        Self {
+            ack_queue: AckQueue::new(),
+            nack_queue: NAckQueue::new(),
+        }
+    }
 }

--- a/src/ack/queue.rs
+++ b/src/ack/queue.rs
@@ -1,127 +1,126 @@
 use super::{Ack, Record, SingleRecord};
-use binary_utils::BinaryStream;
 use std::collections::{HashMap, HashSet};
 /// Stores sequence numbers and their relevant data sets.
 #[derive(Clone, Debug)]
 pub struct AckQueue {
-     current: u32,
-     queue: HashMap<u32, Vec<u8>>,
+    current: u32,
+    queue: HashMap<u32, Vec<u8>>,
 }
 
 impl AckQueue {
-     pub fn new() -> Self {
-          Self {
-               current: 0,
-               queue: HashMap::new(),
-          }
-     }
+    pub fn new() -> Self {
+        Self {
+            current: 0,
+            queue: HashMap::new(),
+        }
+    }
 
-     pub fn make_ack(&mut self) -> Ack {
-          let mut records: Vec<Record> = Vec::new();
+    pub fn make_ack(&mut self) -> Ack {
+        let mut records: Vec<Record> = Vec::new();
 
-          for (seq, _) in self.queue.clone().iter() {
-               self.drop_seq(*seq);
-               records.push(Record::Single(SingleRecord { sequence: *seq }));
-          }
+        for (seq, _) in self.queue.clone().iter() {
+            self.drop_seq(*seq);
+            records.push(Record::Single(SingleRecord { sequence: *seq }));
+        }
 
-          let mut ack = Ack::new(records.len() as u16, true);
-          ack.records = records;
+        let mut ack = Ack::new(records.len() as u16, true);
+        ack.records = records;
 
-          ack
-     }
+        ack
+    }
 
-     pub fn increment_seq(&mut self, by: Option<u32>) {
-          self.current += by.unwrap_or(1);
-     }
+    pub fn increment_seq(&mut self, by: Option<u32>) {
+        self.current += by.unwrap_or(1);
+    }
 
-     pub fn push_seq(&mut self, idx: u32, val: Vec<u8>) {
-          self.queue.insert(idx, val);
-     }
+    pub fn push_seq(&mut self, idx: u32, val: Vec<u8>) {
+        self.queue.insert(idx, val);
+    }
 
-     pub fn drop_seq(&mut self, idx: u32) -> bool {
-          if self.queue.contains_key(&idx) {
-               self.queue.remove_entry(&idx);
-               true
-          } else {
-               false
-          }
-     }
+    pub fn drop_seq(&mut self, idx: u32) -> bool {
+        if self.queue.contains_key(&idx) {
+            self.queue.remove_entry(&idx);
+            true
+        } else {
+            false
+        }
+    }
 
-     pub fn get_seq(&self, idx: u32) -> Option<&Vec<u8>> {
-          if self.queue.contains_key(&idx) {
-               self.queue.get(&idx)
-          } else {
-               None
-          }
-     }
+    pub fn get_seq(&self, idx: u32) -> Option<&Vec<u8>> {
+        if self.queue.contains_key(&idx) {
+            self.queue.get(&idx)
+        } else {
+            None
+        }
+    }
 
-     pub fn has_seq(&self, idx: u32) -> bool {
-          self.queue.contains_key(&idx)
-     }
+    pub fn has_seq(&self, idx: u32) -> bool {
+        self.queue.contains_key(&idx)
+    }
 
-     pub fn is_empty(&self) -> bool {
-          self.queue.len() == 0
-     }
+    pub fn is_empty(&self) -> bool {
+        self.queue.len() == 0
+    }
 }
 
 #[derive(Clone, Debug)]
 pub struct NAckQueue {
-     current: u32,
-     queue: HashSet<u32>,
+    current: u32,
+    queue: HashSet<u32>,
 }
 
 impl NAckQueue {
-     pub fn new() -> Self {
-          Self {
-               current: 0,
-               queue: HashSet::new(),
-          }
-     }
+    pub fn new() -> Self {
+        Self {
+            current: 0,
+            queue: HashSet::new(),
+        }
+    }
 
-     pub fn push_seq(&mut self, idx: u32) {
-          self.queue.insert(idx);
-     }
+    pub fn push_seq(&mut self, idx: u32) {
+        self.queue.insert(idx);
+    }
 
-     pub fn drop_seq(&mut self, idx: u32) -> bool {
-          if self.queue.contains(&idx) {
-               self.queue.remove(&idx);
-               true
-          } else {
-               false
-          }
-     }
+    pub fn drop_seq(&mut self, idx: u32) -> bool {
+        if self.queue.contains(&idx) {
+            self.queue.remove(&idx);
+            true
+        } else {
+            false
+        }
+    }
 
-     pub fn get_seq(&self, idx: u32) -> Option<u32> {
-          if self.queue.contains(&idx) {
-               Some(idx)
-          } else {
-               None
-          }
-     }
+    pub fn get_seq(&self, idx: u32) -> Option<u32> {
+        if self.queue.contains(&idx) {
+            Some(idx)
+        } else {
+            None
+        }
+    }
 
-     pub fn has_seq(&self, idx: u32) -> bool {
-          self.queue.contains(&idx)
-     }
+    pub fn has_seq(&self, idx: u32) -> bool {
+        self.queue.contains(&idx)
+    }
 
-     pub fn is_empty(&self) -> bool {
-          self.queue.len() == 0
-     }
+    pub fn is_empty(&self) -> bool {
+        self.queue.len() == 0
+    }
 
-     pub fn make_nack(&mut self) -> Ack {
-          let mut records: Vec<Record> = Vec::new();
+    pub fn make_nack(&mut self) -> Ack {
+        let mut records: Vec<Record> = Vec::new();
 
-          for seq in self.queue.clone().iter() {
-               self.drop_seq(*seq);
-               records.push(Record::Single(SingleRecord { sequence: *seq }));
-          }
+        for seq in self.queue.clone().iter() {
+            self.drop_seq(*seq);
+            records.push(Record::Single(SingleRecord { sequence: *seq }));
+        }
 
-          let mut ack = Ack::new(records.len() as u16, false);
-          ack.records = records;
+        let mut ack = Ack::new(records.len() as u16, false);
+        ack.records = records;
 
-          ack
-     }
+        ack
+    }
 
-     pub fn increment_seq(&mut self, by: Option<u32>) {
-          self.current += by.unwrap_or(1);
-     }
+    pub fn increment_seq(&mut self, by: Option<u32>) {
+        self.current += by.unwrap_or(1);
+    }
 }

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -8,371 +8,377 @@ use crate::reliability::{Reliability, ReliabilityFlag};
 use crate::util::tokenize_addr;
 use crate::{Motd, RakNetEvent};
 use binary_utils::*;
+use byteorder::ReadBytesExt;
 use std::collections::VecDeque;
+use std::io::Cursor;
 use std::net::SocketAddr;
-use std::sync::{Arc};
+use std::sync::Arc;
 use std::time::SystemTime;
-use std::io::{Read, Write, Cursor};
-use byteorder::{ReadBytesExt, WriteBytesExt, BigEndian};
 
 pub type RecievePacketFn = fn(&mut Connection, &mut Vec<u8>);
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum ConnectionState {
-     Connecting,
-     Connected,
-     Disconnected,
-     TimingOut,
-     Offline,
+    Connecting,
+    Connected,
+    Disconnected,
+    TimingOut,
+    Offline,
 }
 
 impl ConnectionState {
-     /// Whether or not the ConnectionState is `Disconnected`.
-     pub fn is_disconnected(&self) -> bool {
-          match *self {
-               Self::Disconnected => true,
-               _ => false,
-          }
-     }
+    /// Whether or not the ConnectionState is `Disconnected`.
+    pub fn is_disconnected(&self) -> bool {
+        match *self {
+            Self::Disconnected => true,
+            _ => false,
+        }
+    }
 
-     /// Whether or not the ConnectionState is `Connected`.
-     pub fn is_connected(&self) -> bool {
-          match *self {
-               Self::Connected => true,
-               _ => false,
-          }
-     }
+    /// Whether or not the ConnectionState is `Connected`.
+    pub fn is_connected(&self) -> bool {
+        match *self {
+            Self::Connected => true,
+            _ => false,
+        }
+    }
 
-     /// Whether or not the Connection is:
-     /// - **Connected** or **TimingOut**
-     pub fn is_available(&self) -> bool {
-          match *self {
-               Self::Offline | Self::TimingOut => false,
-               _ => true,
-          }
-     }
+    /// Whether or not the Connection is:
+    /// - **Connected** or **TimingOut**
+    pub fn is_available(&self) -> bool {
+        match *self {
+            Self::Offline | Self::TimingOut => false,
+            _ => true,
+        }
+    }
 
-     /// Whether or not the Connection can reliably recieve
-     /// a buffer, the states that return true are:
-     /// - **Connected**
-     /// - **Connecting**
-     /// - **Disconnected**
-     pub fn is_reliable(&self) -> bool {
-          match *self {
-               Self::Disconnected | Self::Connected | Self::Connecting => true,
-               _ => false,
-          }
-     }
+    /// Whether or not the Connection can reliably recieve
+    /// a buffer, the states that return true are:
+    /// - **Connected**
+    /// - **Connecting**
+    /// - **Disconnected**
+    pub fn is_reliable(&self) -> bool {
+        match *self {
+            Self::Disconnected | Self::Connected | Self::Connecting => true,
+            _ => false,
+        }
+    }
 }
 
 #[derive(Clone)]
 pub struct Connection {
-     /// The address the client is connected with.
-     pub address: SocketAddr,
-     /// The start time of the `RakNetServer`.
-     pub time: SystemTime,
-     /// The **Max transfer unit** for the client.
-     /// Outbound buffers will be reduced to this unit.
-     pub mtu_size: u16,
-     /// The state of the given connection.
-     /// States include:
-     /// - **Connecting**: Client is not connected, but is performing connection sequence.
-     /// - **Connected**: Client has performed connection sequence and is reliable.
-     /// - **Disconnected**: The client is sending information, but is not connected to the server.
-     /// - **Offline**: We have stopped recieving responses from the client.
-     pub state: ConnectionState,
-     /// A list of events to be emitted on next tick.
-     pub event_dispatch: VecDeque<RakNetEvent>,
-     /// A function that is called when the server recieves a
-     /// `GamePacket: 0xfe` from the client.
-     // pub recv: Arc<RecievePacketFn>,
-     /// The last time the client has sent something to the server, that was a connected packet.
-     pub recv_time: SystemTime,
-     /// A Vector of streams to be sent.
-     /// This should almost always be a Frame, with exceptions
-     /// to offline packets.
-     pub send_queue: VecDeque<Vec<u8>>,
-     /// A list of buffers that exceed the MTU size
-     /// This queue will be shortened into individual fragments,
-     /// and sent to the client as fragmented frames.
-     send_queue_large: VecDeque<Vec<u8>>,
-     /// Stores the fragmented frames by their
-     /// `frame_index` value from a given packet.
-     /// When a `FrameList` is ready from a `FragmentStore` it's assembled
-     /// into a `FramePacket` which can then be added to the `send_queue`.
-     fragmented: FragmentStore,
-     /// Stores the next available fragment id.
-     /// This variable will reset after the sequence
-     /// containing the fragment id's we sent has been
-     /// acknowledged by the client.
-     ///
-     /// However in the event this never occurs, fragment id will reset after
-     /// it reaches `65535` as a value
-     fragment_id: u16,
-     /// The last recieved sequence id
-     recv_seq: u32,
-     /// The last send sequence id used
-     send_seq: u32,
-     /// The ACK queue (packets we got)
-     ack: AckQueue,
-     /// The NACK queue (Packets we didn't get)
-     nack: NAckQueue,
-     /// The Motd reference.
-     motd: Arc<Motd>,
+    /// The address the client is connected with.
+    pub address: SocketAddr,
+    /// The address of the client, however it's tokenized.
+    pub address_token: String,
+    /// The start time of the `RakNetServer`.
+    pub time: SystemTime,
+    /// The **Max transfer unit** for the client.
+    /// Outbound buffers will be reduced to this unit.
+    pub mtu_size: u16,
+    /// The state of the given connection.
+    /// States include:
+    /// - **Connecting**: Client is not connected, but is performing connection sequence.
+    /// - **Connected**: Client has performed connection sequence and is reliable.
+    /// - **Disconnected**: The client is sending information, but is not connected to the server.
+    /// - **Offline**: We have stopped recieving responses from the client.
+    pub state: ConnectionState,
+    /// A list of events to be emitted on next tick.
+    pub event_dispatch: VecDeque<RakNetEvent>,
+    /// A function that is called when the server recieves a
+    /// `GamePacket: 0xfe` from the client.
+    // pub recv: Arc<RecievePacketFn>,
+    /// The last time the client has sent something to the server, that was a connected packet.
+    pub recv_time: SystemTime,
+    /// A Vector of streams to be sent.
+    /// This should almost always be a Frame, with exceptions
+    /// to offline packets.
+    pub send_queue: VecDeque<Vec<u8>>,
+    /// A list of buffers that exceed the MTU size
+    /// This queue will be shortened into individual fragments,
+    /// and sent to the client as fragmented frames.
+    send_queue_large: VecDeque<Vec<u8>>,
+    /// Stores the fragmented frames by their
+    /// `frame_index` value from a given packet.
+    /// When a `FrameList` is ready from a `FragmentStore` it's assembled
+    /// into a `FramePacket` which can then be added to the `send_queue`.
+    fragmented: FragmentStore,
+    /// Stores the next available fragment id.
+    /// This variable will reset after the sequence
+    /// containing the fragment id's we sent has been
+    /// acknowledged by the client.
+    ///
+    /// However in the event this never occurs, fragment id will reset after
+    /// it reaches `65535` as a value
+    fragment_id: u16,
+    /// The last recieved sequence id
+    recv_seq: u32,
+    /// The last send sequence id used
+    send_seq: u32,
+    /// The ACK queue (packets we got)
+    ack: AckQueue,
+    /// The NACK queue (Packets we didn't get)
+    nack: NAckQueue,
+    /// The Motd reference.
+    motd: Arc<Motd>,
 }
 
 impl Connection {
-     pub fn new(
-          address: SocketAddr,
-          start_time: SystemTime,
-          recv: Arc<RecievePacketFn>,
-          motd: Arc<Motd>,
-     ) -> Self {
-          Self {
-               address,
-               time: start_time,
-               recv_time: SystemTime::now(),
-               mtu_size: 2048,
-               state: ConnectionState::Disconnected,
-               event_dispatch: VecDeque::new(),
-               // recv,
-               send_queue: VecDeque::new(),
-               send_queue_large: VecDeque::new(),
-               fragmented: FragmentStore::new(),
-               recv_seq: 0,
-               send_seq: 0,
-               fragment_id: 0,
-               ack: AckQueue::new(),
-               nack: NAckQueue::new(),
-               motd,
-          }
-     }
+    pub fn new(address: SocketAddr, start_time: SystemTime, motd: Arc<Motd>) -> Self {
+        Self {
+            address,
+            address_token: tokenize_addr(address),
+            time: start_time,
+            recv_time: SystemTime::now(),
+            mtu_size: 2048,
+            state: ConnectionState::Disconnected,
+            event_dispatch: VecDeque::new(),
+            // recv,
+            send_queue: VecDeque::new(),
+            send_queue_large: VecDeque::new(),
+            fragmented: FragmentStore::new(),
+            recv_seq: 0,
+            send_seq: 0,
+            fragment_id: 0,
+            ack: AckQueue::new(),
+            nack: NAckQueue::new(),
+            motd,
+        }
+    }
 
-     /// Send a binary stream to the specified client.
-     pub fn send(&mut self, stream: Vec<u8>, instant: bool) {
-          if instant {
-               let mut frame_packet = FramePacket::new();
-               let mut frame = Frame::init();
-               frame.reliability = Reliability::new(ReliabilityFlag::Unreliable);
-               frame.body = stream;
-               frame_packet.seq = self.next_send_seq().into();
-               frame_packet.frames.push(frame);
-               self.send_queue.push_back(frame_packet.parse());
-          } else {
-               self.send_queue_large.push_back(stream);
-          }
-     }
+    /// Send a binary stream to the specified client.
+    pub fn send(&mut self, stream: Vec<u8>, instant: bool) {
+        if instant {
+            let mut frame_packet = FramePacket::new();
+            let mut frame = Frame::init();
+            frame.reliability = Reliability::new(ReliabilityFlag::Unreliable);
+            frame.body = stream;
+            frame_packet.seq = self.next_send_seq().into();
+            frame_packet.frames.push(frame);
+            self.send_queue.push_back(frame_packet.parse());
+        } else {
+            self.send_queue_large.push_back(stream);
+        }
+    }
 
-     /// The recieve handle for a connection.
-     /// This is called when RakNet parses any given byte buffer from the socket.
-     pub fn recv(&mut self, buf: &Vec<u8>) {
-          let mut stream = Cursor::new(buf);
-          // Update the recieve time.
-          self.recv_time = SystemTime::now();
-          if self.state.is_disconnected() {
-               let pk = OfflinePackets::recv(stream.read_u8().unwrap());
-               let handler = handle_offline(self, pk, stream.get_mut());
-               self.send_queue.push_back(handler);
-          } else {
-               // this packet is almost always a frame packet
-               let online_packet = OnlinePackets::recv(stream.read_u8().unwrap());
+    /// The recieve handle for a connection.
+    /// This is called when RakNet parses any given byte buffer from the socket.
+    pub fn recv(&mut self, buf: &Vec<u8>) {
+        let mut stream = Cursor::new(buf);
+        // Update the recieve time.
+        self.recv_time = SystemTime::now();
+        if self.state.is_disconnected() {
+            let pk = OfflinePackets::recv(stream.read_u8().unwrap());
+            let handler = handle_offline(self, pk, stream.get_mut());
+            self.send_queue.push_back(handler);
+        } else {
+            // this packet is almost always a frame packet
+            let online_packet = OnlinePackets::recv(stream.read_u8().unwrap());
 
-               if is_ack_or_nack(online_packet.to_byte()) {
-                    stream.set_position(0);
-                    return self.handle_ack(stream.get_ref().clone());
-               }
+            if is_ack_or_nack(online_packet.to_byte()) {
+                stream.set_position(0);
+                return self.handle_ack(stream.get_ref().clone());
+            }
 
-               match online_packet {
-                    OnlinePackets::Disconnect => {
-                         self.state = ConnectionState::Offline;
-                         self.event_dispatch.push_back(RakNetEvent::Disconnect(
-                              tokenize_addr(self.address),
-                              "Client disconnect".to_owned(),
-                         ));
-                         return;
-                    }
-                    OnlinePackets::FramePacket(_) => {
-                         let mut frame_packet = FramePacket::compose(stream.get_ref(), &mut (stream.position() as usize));
+            match online_packet {
+                OnlinePackets::Disconnect => {
+                    self.state = ConnectionState::Offline;
+                    self.event_dispatch.push_back(RakNetEvent::Disconnect(
+                        tokenize_addr(self.address),
+                        "Client disconnect".to_owned(),
+                    ));
+                    return;
+                }
+                OnlinePackets::FramePacket(_) => {
+                    let mut frame_packet =
+                        FramePacket::compose(stream.get_ref(), &mut (stream.position() as usize));
 
-                         self.handle_frames(&mut frame_packet);
-                         return;
-                    }
-                    _ => {}
-               }
-          }
-     }
+                    self.handle_frames(&mut frame_packet);
+                    return;
+                }
+                _ => {}
+            }
+        }
+    }
 
-     /// When the client sends an **Acknowledge**, we check:
-     /// - If we have already recieved this packet.
-     ///   If so, we respectfully ignore the packet.
-     ///
-     /// - The "records" in the acknowledge packet.
-     ///   We iterate through the records, and if
-     ///   any record sequence **does not exist**
-     ///   we add this sequence number to the **Nack** queue,
-     ///   which is then sent to the client when the connection ticks
-     ///   to *hopefully* force the client to eventually send that packet.
-     pub fn handle_ack(&mut self, packet: &Vec<u8>) {
+    /// When the client sends an **Acknowledge**, we check:
+    /// - If we have already recieved this packet.
+    ///   If so, we respectfully ignore the packet.
+    ///
+    /// - The "records" in the acknowledge packet.
+    ///   We iterate through the records, and if
+    ///   any record sequence **does not exist**
+    ///   we add this sequence number to the **Nack** queue,
+    ///   which is then sent to the client when the connection ticks
+    ///   to *hopefully* force the client to eventually send that packet.
+    pub fn handle_ack(&mut self, packet: &Vec<u8>) {
+        let got = Ack::compose(&packet[..], &mut 0);
 
-          let got = Ack::compose(&packet[..], &mut 0);
+        for record in got.records {
+            if record.is_single() {
+                let sequence = match record {
+                    Record::Single(rec) => rec.sequence,
+                    _ => continue,
+                };
 
-          for record in got.records {
-               if record.is_single() {
-                    let sequence = match record {
-                         Record::Single(rec) => rec.sequence,
-                         _ => continue,
-                    };
+                if !self.ack.has_seq(sequence) {
+                    self.nack.push_seq(sequence);
+                }
+            } else {
+                let range = match record {
+                    Record::Range(rec) => rec,
+                    _ => continue,
+                };
 
+                let sequences = range.get_sequences();
+
+                for sequence in sequences {
                     if !self.ack.has_seq(sequence) {
-                         self.nack.push_seq(sequence);
+                        self.nack.push_seq(sequence);
                     }
-               } else {
-                    let range = match record {
-                         Record::Range(rec) => rec,
-                         _ => continue,
-                    };
+                }
+            }
+        }
+    }
 
-                    let sequences = range.get_sequences();
+    /// Iterates over every `Frame` of the `FramePacket` and does the following checks:
+    /// - Checks if the frame is fragmented, if it is,
+    ///   we check if all fragments have been sent to the server.
+    ///   If all packets have been sent, we "re-assemble" them.
+    ///   If not, we simply add the fragment to a fragment list,
+    ///   and continue to the next frame
+    ///
+    /// - If it is not fragmented, we handle the frames body. (Which should contain a valid RakNet payload)
+    pub fn handle_frames(&mut self, frame_packet: &mut FramePacket) {
+        self.recv_seq = frame_packet.seq.into();
+        self.ack
+            .push_seq(frame_packet.seq.into(), frame_packet.parse());
+        for frame in frame_packet.frames.iter_mut() {
+            if frame.fragment_info.is_some() {
+                // the frame is fragmented!
+                self.fragmented.add_frame(frame.clone());
+                let frag_list = &self
+                    .fragmented
+                    .get(frame.fragment_info.unwrap().fragment_id);
 
-                    for sequence in sequences {
-                         if !self.ack.has_seq(sequence) {
-                              self.nack.push_seq(sequence);
-                         }
+                if frag_list.is_some() {
+                    let mut list = frag_list.clone().unwrap();
+                    let pk = list.reassemble_frame();
+                    if pk.is_some() {
+                        self.handle_full_frame(&mut pk.unwrap());
+                        self.fragmented
+                            .remove(frame.fragment_info.unwrap().fragment_id.into());
                     }
-               }
-          }
-     }
+                }
+                continue;
+            } else {
+                self.handle_full_frame(frame);
+            }
+        }
+    }
 
-     /// Iterates over every `Frame` of the `FramePacket` and does the following checks:
-     /// - Checks if the frame is fragmented, if it is,
-     ///   we check if all fragments have been sent to the server.
-     ///   If all packets have been sent, we "re-assemble" them.
-     ///   If not, we simply add the fragment to a fragment list,
-     ///   and continue to the next frame
-     ///
-     /// - If it is not fragmented, we handle the frames body. (Which should contain a valid RakNet payload)
-     pub fn handle_frames(&mut self, frame_packet: &mut FramePacket) {
-          self.ack.push_seq(frame_packet.seq.into(), frame_packet.parse());
-          for frame in frame_packet.frames.iter_mut() {
-               if frame.fragment_info.is_some() {
-                    // the frame is fragmented!
-                    self.fragmented.add_frame(frame.clone());
-                    let frag_list = &self
-                         .fragmented
-                         .get(frame.fragment_info.unwrap().fragment_id);
+    /// Handles the full frame from the client.
+    fn handle_full_frame(&mut self, frame: &mut Frame) {
+        // todo Check if the frames should be recieved, if not purge them
+        // todo EG: add implementation for ordering and sequenced frames!
+        let mut body_stream = Cursor::new(frame.body.clone());
+        let online_packet = OnlinePackets::recv(body_stream.read_u8().unwrap());
 
-                    if frag_list.is_some() {
-                         let mut list = frag_list.clone().unwrap();
-                         let pk = list.reassemble_frame();
-                         if pk.is_some() {
-                              self.handle_full_frame(&mut pk.unwrap());
-                              self.fragmented
-                                   .remove(frame.fragment_info.unwrap().fragment_id.into());
-                         }
-                    }
-                    continue;
-               } else {
-                    self.handle_full_frame(frame);
-               }
-          }
-     }
+        if online_packet == OnlinePackets::GamePacket {
+            // self.recv.as_ref()(self, &mut body_stream.get_mut());
+            // we don't really care what happens to game packet, so emit it.
+            self.event_dispatch.push_back(RakNetEvent::GamePacket(
+                self.address_token.clone(),
+                frame.body.clone(),
+            ));
+        } else {
+            let response = handle_online(self, online_packet.clone(), &mut frame.body);
 
-     /// Handles the full frame from the client.
-     fn handle_full_frame(&mut self, frame: &mut Frame) {
-          // todo Check if the frames should be recieved, if not purge them
-          // todo EG: add implementation for ordering and sequenced frames!
-          let mut body_stream = Cursor::new(frame.body.clone());
-          let online_packet = OnlinePackets::recv(body_stream.read_u8().unwrap());
+            if response.len() != 0 {
+                let mut new_framepk = FramePacket::new();
+                let mut new_frame = Frame::init();
 
-          if online_packet == OnlinePackets::GamePacket {
-               // self.recv.as_ref()(self, &mut body_stream.get_mut());
-               // we don't really care what happens to game packet, so emit it.
-               self.event_dispatch.push_back(RakNetEvent::GamePacket())
-          } else {
-               let response = handle_online(self, online_packet.clone(), &mut frame.body);
+                new_frame.body = response;
+                new_frame.reliability = Reliability::new(ReliabilityFlag::Unreliable);
+                new_framepk.frames.push(new_frame);
+                new_framepk.seq = self.send_seq.into();
+                self.send_queue.push_back(new_framepk.parse());
+                self.send_seq = self.send_seq + 1;
+            }
+        }
+    }
 
-               if response.len() != 0 {
-                    let mut new_framepk = FramePacket::new();
-                    let mut new_frame = Frame::init();
+    pub fn next_send_seq(&mut self) -> u32 {
+        let old = self.send_seq.clone();
+        self.send_seq += 1;
+        old
+    }
 
-                    new_frame.body = response;
-                    new_frame.reliability = Reliability::new(ReliabilityFlag::Unreliable);
-                    new_framepk.frames.push(new_frame);
-                    new_framepk.seq = self.send_seq.into();
-                    self.send_queue.push_back(new_framepk.parse());
-                    self.send_seq = self.send_seq + 1;
-               }
-          }
-     }
+    /// Called when RakNet is ready to "tick" this client.
+    /// Each "tick" the following things are done:
+    ///
+    /// - Send all **Ack** and **Nack** queues to the client.
+    ///
+    /// - Fragments everything in the `send_queue_large` queue,
+    ///   and then appends all of these "buffers" or "Streams"
+    ///   to be sent by raknet on the next iteration.
+    pub fn do_tick(&mut self) {
+        if self.state == ConnectionState::Offline {
+            return;
+        }
 
-     pub fn next_send_seq(&mut self) -> u32 {
-          let old = self.send_seq.clone();
-          self.send_seq += 1;
-          old
-     }
+        if self.recv_time.elapsed().unwrap().as_secs() >= 10 {
+            self.state = ConnectionState::Offline;
+            self.event_dispatch.push_back(RakNetEvent::Disconnect(
+                tokenize_addr(self.address),
+                "Time Out".to_owned(),
+            ));
+            return;
+        }
 
-     /// Called when RakNet is ready to "tick" this client.
-     /// Each "tick" the following things are done:
-     ///
-     /// - Send all **Ack** and **Nack** queues to the client.
-     ///
-     /// - Fragments everything in the `send_queue_large` queue,
-     ///   and then appends all of these "buffers" or "Streams"
-     ///   to be sent by raknet on the next iteration.
-     pub fn do_tick(&mut self) {
-          if self.state == ConnectionState::Offline {
-               return;
-          }
+        if self.recv_time.elapsed().unwrap().as_secs() >= 5 && self.state.is_reliable() {
+            self.state = ConnectionState::TimingOut;
+        }
 
-          if self.recv_time.elapsed().unwrap().as_secs() >= 10 {
-               self.state = ConnectionState::Offline;
-               self.event_dispatch.push_back(RakNetEvent::Disconnect(tokenize_addr(self.address), "Time Out".to_owned()));
-               return;
-          }
+        if self.state.is_reliable() {
+            if !self.ack.is_empty() {
+                let respond_with = self.ack.make_ack();
+                self.send_queue.push_back(respond_with.parse());
+            }
 
-          if self.recv_time.elapsed().unwrap().as_secs() >= 5 && self.state.is_reliable() {
-               self.state = ConnectionState::TimingOut;
-          }
+            if !self.nack.is_empty() {
+                let respond_with = self.nack.make_nack();
+                self.send_queue.push_back(respond_with.parse());
+            }
+        }
 
-          if self.state.is_reliable() {
-               if !self.ack.is_empty() {
-                    let respond_with = self.ack.make_ack();
-                    self.send_queue.push_back(respond_with.parse());
-               }
+        let mut current_frames: Vec<FragmentList> = Vec::new();
+        let safe_size = self.mtu_size - 15;
 
-               if !self.nack.is_empty() {
-                    let respond_with = self.nack.make_nack();
-                    self.send_queue.push_back(respond_with.parse());
-               }
-          }
+        // Make seperate buffers from the large queue based on the MTUSize saving
+        // space for frame packet header
+        for part in self.send_queue_large.iter_mut() {
+            current_frames.push(FragmentList::from(part, safe_size.into()));
+        }
 
-          let mut current_frames: Vec<FragmentList> = Vec::new();
-          let safe_size = self.mtu_size - 15;
+        for safely_sized in current_frames.iter_mut() {
+            let packets = safely_sized.assemble(safe_size as i16, self.fragment_id);
 
-          // Make seperate buffers from the large queue based on the MTUSize saving
-          // space for frame packet header
-          for part in self.send_queue_large.iter_mut() {
-               current_frames.push(FragmentList::from(part, safe_size.into()));
-          }
+            if packets.is_some() {
+                for pk in packets.unwrap() {
+                    self.send_queue.push_back(pk.parse());
+                }
 
-          for safely_sized in current_frames.iter_mut() {
-               let packets = safely_sized.assemble(safe_size as i16, self.fragment_id);
+                self.fragment_id += 1;
 
-               if packets.is_some() {
-                    for pk in packets.unwrap() {
-                         self.send_queue.push_back(pk.parse());
-                    }
+                if self.fragment_id == 65534 {
+                    self.fragment_id = 0;
+                }
+            }
+        }
+    }
 
-                    self.fragment_id += 1;
-
-                    if self.fragment_id == 65534 {
-                         self.fragment_id = 0;
-                    }
-               }
-          }
-     }
-
-     pub fn get_motd(&self) -> Motd {
-          self.motd.as_ref().clone()
-     }
+    pub fn get_motd(&self) -> Motd {
+        self.motd.as_ref().clone()
+    }
 }

--- a/src/frame/fragment.rs
+++ b/src/frame/fragment.rs
@@ -4,177 +4,180 @@ use super::{Frame, FramePacket};
 use binary_utils::*;
 use std::collections::HashMap;
 use std::io::Cursor;
-use std::io::{Write, Read};
+use std::io::Write;
 
 #[derive(Copy, Clone, Debug)]
 pub struct FragmentInfo {
-     pub fragment_size: i32,
-     pub fragment_id: u16,
-     pub fragment_index: i32,
+    pub fragment_size: i32,
+    pub fragment_id: u16,
+    pub fragment_index: i32,
 }
 
 impl FragmentInfo {
-     pub fn new(fragment_size: i32, fragment_id: u16, fragment_index: i32) -> Self {
-          Self {
-               fragment_size,
-               fragment_id,
-               fragment_index,
-          }
-     }
+    pub fn new(fragment_size: i32, fragment_id: u16, fragment_index: i32) -> Self {
+        Self {
+            fragment_size,
+            fragment_id,
+            fragment_index,
+        }
+    }
 }
 
 /// A Fragment recieved from any frame.
 /// Fragments can be reassembled by the FragmentQueue.
 #[derive(Clone, Debug)]
 pub struct Fragment {
-     index: i32,
-     buffer: Vec<u8>,
+    index: i32,
+    buffer: Vec<u8>,
 }
 
 impl Fragment {
-     pub fn new(index: i32, buffer: Vec<u8>) -> Self {
-          Self { index, buffer }
-     }
-     pub fn get_index(&self) -> i32 {
-          self.index.clone()
-     }
+    pub fn new(index: i32, buffer: Vec<u8>) -> Self {
+        Self { index, buffer }
+    }
+    pub fn get_index(&self) -> i32 {
+        self.index.clone()
+    }
 
-     pub fn get_buffer(&self) -> &[u8] {
-          &*self.buffer
-     }
+    pub fn get_buffer(&self) -> &[u8] {
+        &*self.buffer
+    }
 
-     pub fn as_stream(&self) -> Vec<u8> {
-          self.buffer.to_vec()
-     }
+    pub fn as_stream(&self) -> Vec<u8> {
+        self.buffer.to_vec()
+    }
 }
 
 /// A list of fragments
 /// Holds a list of fragments until they are complete.
 #[derive(Clone, Debug)]
 pub struct FragmentList {
-     pub fragments: HashMap<i32, Fragment>,
-     size: u64,
+    pub fragments: HashMap<i32, Fragment>,
+    size: u64,
 }
 
 impl FragmentList {
-     pub fn new() -> Self {
-          Self {
-               fragments: HashMap::new(),
-               size: 0,
-          }
-     }
+    pub fn new() -> Self {
+        Self {
+            fragments: HashMap::new(),
+            size: 0,
+        }
+    }
 
-     pub fn from(buf: &mut Vec<u8>, part_size: usize) -> Self {
-          let mut stream = Cursor::new(buf);
-          let mut fragments: HashMap<i32, Fragment> = HashMap::new();
-          let mut current_index: i32 = 0;
+    pub fn from(buf: &mut Vec<u8>, part_size: usize) -> Self {
+        let stream = Cursor::new(buf);
+        let mut fragments: HashMap<i32, Fragment> = HashMap::new();
+        let mut current_index: i32 = 0;
 
-          while (stream.position() + part_size as u64) < (stream.get_ref().len() as u64) {
-               let part = &stream.get_ref()[stream.position() as usize..(stream.position() as usize + part_size)];
-               fragments.insert(current_index, Fragment::new(current_index, part.to_vec()));
-               current_index += 1;
-          }
+        while (stream.position() + part_size as u64) < (stream.get_ref().len() as u64) {
+            let part = &stream.get_ref()
+                [stream.position() as usize..(stream.position() as usize + part_size)];
+            fragments.insert(current_index, Fragment::new(current_index, part.to_vec()));
+            current_index += 1;
+        }
 
-          // read the rest if for some reason the above failed
-          if stream.position() < stream.get_ref().len() as u64 {
-               let next_part = stream.remaining_slice().to_vec();
-               fragments.insert(current_index, Fragment::new(current_index, next_part));
-          }
+        // read the rest if for some reason the above failed
+        if stream.position() < stream.get_ref().len() as u64 {
+            let next_part = stream.remaining_slice().to_vec();
+            fragments.insert(current_index, Fragment::new(current_index, next_part));
+        }
 
-          Self {
-               fragments: fragments.clone(),
-               size: fragments.len() as u64,
-          }
-     }
+        Self {
+            fragments: fragments.clone(),
+            size: fragments.len() as u64,
+        }
+    }
 
-     /// Adds a binary stream to the fragment list.
-     pub fn add_stream(&mut self, _buf: Vec<u8>) {}
+    /// Adds a binary stream to the fragment list.
+    pub fn add_stream(&mut self, _buf: Vec<u8>) {}
 
-     pub fn add_fragment(&mut self, frag: Fragment) {
-          if !self.includes(frag.get_index()) {
-               self.fragments.insert(frag.get_index(), frag);
-          }
-     }
+    pub fn add_fragment(&mut self, frag: Fragment) {
+        if !self.includes(frag.get_index()) {
+            self.fragments.insert(frag.get_index(), frag);
+        }
+    }
 
-     /// Reassembles a list of fragments,
-     /// assumes that you want to join the fragments into a single frame
-     pub fn reassemble_frame(&mut self) -> Option<Frame> {
-          // sort the frames
-          self.sort();
+    /// Reassembles a list of fragments,
+    /// assumes that you want to join the fragments into a single frame
+    pub fn reassemble_frame(&mut self) -> Option<Frame> {
+        // sort the frames
+        self.sort();
 
-          if !self.is_ready() {
-               None
-          } else {
-               let mut frame = Frame::init();
-               for i in 0..self.get_size() {
-                    let frag = self.fragments.get(&(i as i32)).unwrap();
-                    frame.body.write_all(&frag.get_buffer());
-               }
+        if !self.is_ready() {
+            None
+        } else {
+            let mut frame = Frame::init();
+            for i in 0..self.get_size() {
+                let frag = self.fragments.get(&(i as i32)).unwrap();
+                frame
+                    .body
+                    .write_all(&frag.get_buffer())
+                    .expect("Could not write all data into frame.");
+            }
 
-               // we can now drop the fragment from the table
+            // we can now drop the fragment from the table
 
-               Some(frame)
-          }
-     }
+            Some(frame)
+        }
+    }
 
-     pub fn assemble(&mut self, mtu_size: i16, usable_id: u16) -> Option<Vec<FramePacket>> {
-          let mut framepks = Vec::new();
-          let mut framepk = FramePacket::new();
-          // sort the frames
-          self.sort();
+    pub fn assemble(&mut self, mtu_size: i16, usable_id: u16) -> Option<Vec<FramePacket>> {
+        let mut framepks = Vec::new();
+        let mut framepk = FramePacket::new();
+        // sort the frames
+        self.sort();
 
-          if !self.is_ready() {
-               None
-          } else {
-               let mut index = 0;
-               for (_, frag) in self.fragments.iter() {
-                    let mut frame = Frame::init();
-                    frame.fragment_info =
-                         Some(FragmentInfo::new(self.size as i32, usable_id, index));
-                    frame.body = frag.as_stream();
+        if !self.is_ready() {
+            None
+        } else {
+            let mut index = 0;
+            for (_, frag) in self.fragments.iter() {
+                let mut frame = Frame::init();
+                frame.fragment_info = Some(FragmentInfo::new(self.size as i32, usable_id, index));
+                frame.body = frag.as_stream();
 
-                    if framepk.parse().len() + frame.parse().len() >= mtu_size as usize {
-                         framepks.push(framepk);
-                         framepk = FramePacket::new();
-                    }
+                if framepk.parse().len() + frame.parse().len() >= mtu_size as usize {
+                    framepks.push(framepk);
+                    framepk = FramePacket::new();
+                }
 
-                    index += 1;
-               }
+                index += 1;
+            }
 
-               Some(framepks)
-          }
-     }
+            Some(framepks)
+        }
+    }
 
-     /// Gets the **wanted** size of fragments
-     pub fn get_size(&self) -> u64 {
-          self.size.clone()
-     }
+    /// Gets the **wanted** size of fragments
+    pub fn get_size(&self) -> u64 {
+        self.size.clone()
+    }
 
-     pub fn get_remaining_size(&self) -> u64 {
-          let amount = self.size.clone() as i64 - self.fragments.len() as i64;
-          if amount <= 0 {
-               0
-          } else {
-               amount as u64
-          }
-     }
+    pub fn get_remaining_size(&self) -> u64 {
+        let amount = self.size.clone() as i64 - self.fragments.len() as i64;
+        if amount <= 0 {
+            0
+        } else {
+            amount as u64
+        }
+    }
 
-     /// Gets the **current** size of fragments
-     pub fn length(&self) -> usize {
-          self.fragments.len()
-     }
+    /// Gets the **current** size of fragments
+    pub fn length(&self) -> usize {
+        self.fragments.len()
+    }
 
-     /// Returns whether the wanted size is the same as the fragment list length.
-     pub fn is_ready(&self) -> bool {
-          self.length() == self.get_size() as usize
-     }
+    /// Returns whether the wanted size is the same as the fragment list length.
+    pub fn is_ready(&self) -> bool {
+        self.length() == self.get_size() as usize
+    }
 
-     /// Sorts all fragments by their index
-     pub fn sort(&mut self) {}
+    /// Sorts all fragments by their index
+    pub fn sort(&mut self) {}
 
-     pub fn includes(&self, idx: i32) -> bool {
-          self.fragments.contains_key(&idx)
-     }
+    pub fn includes(&self, idx: i32) -> bool {
+        self.fragments.contains_key(&idx)
+    }
 }
 
 /// Stores fragmented frames by their frame index.
@@ -185,121 +188,116 @@ impl FragmentList {
 /// This is only used if a frame is fragmented to begin with, otherwise it should be ignored.
 #[derive(Clone, Debug)]
 pub struct FragmentStore {
-     /// A map of current fragments.
-     pub fragment_table: HashMap<i32, FragmentList>,
-     sequence: i32,
+    /// A map of current fragments.
+    pub fragment_table: HashMap<i32, FragmentList>,
+    sequence: i32,
 }
 
 impl FragmentStore {
-     pub fn new() -> Self {
-          FragmentStore {
-               fragment_table: HashMap::new(),
-               sequence: 0,
-          }
-     }
+    pub fn new() -> Self {
+        FragmentStore {
+            fragment_table: HashMap::new(),
+            sequence: 0,
+        }
+    }
 
-     pub fn get(&self, idx: u16) -> Option<FragmentList> {
-          match self.fragment_table.get(&idx.into()) {
-               Some(v) => Some(v.clone()),
-               None => None,
-          }
-     }
+    pub fn get(&self, idx: u16) -> Option<FragmentList> {
+        match self.fragment_table.get(&idx.into()) {
+            Some(v) => Some(v.clone()),
+            None => None,
+        }
+    }
 
-     pub fn remove(&mut self, idx: u16) -> bool {
-          if self.fragment_table.contains_key(&idx.into()) {
-               self.fragment_table.remove(&idx.into());
-               true
-          } else {
-               false
-          }
-     }
+    pub fn remove(&mut self, idx: u16) -> bool {
+        if self.fragment_table.contains_key(&idx.into()) {
+            self.fragment_table.remove(&idx.into());
+            true
+        } else {
+            false
+        }
+    }
 
-     /// Adds a stream into it's given sequence.
-     /// Do note, this does not make them frames.
-     pub fn add_stream(&mut self, buf: Vec<u8>) {
-          if !self.fragment_table.contains_key(&self.sequence) {
-               let list = FragmentList::new();
-               self.fragment_table.insert(self.sequence, list);
-          } else {
-               self.fragment_table
-                    .get_mut(&self.sequence)
-                    .unwrap()
-                    .add_stream(buf);
-          }
-     }
+    /// Adds a stream into it's given sequence.
+    /// Do note, this does not make them frames.
+    pub fn add_stream(&mut self, buf: Vec<u8>) {
+        if !self.fragment_table.contains_key(&self.sequence) {
+            let list = FragmentList::new();
+            self.fragment_table.insert(self.sequence, list);
+        } else {
+            self.fragment_table
+                .get_mut(&self.sequence)
+                .unwrap()
+                .add_stream(buf);
+        }
+    }
 
-     pub fn add_frame(&mut self, frame: Frame) {
-          if !self
-               .fragment_table
-               .contains_key(&frame.fragment_info.unwrap().fragment_id.into())
-          {
-               let mut list = FragmentList::new();
-               list.add_fragment(Fragment {
+    pub fn add_frame(&mut self, frame: Frame) {
+        if !self
+            .fragment_table
+            .contains_key(&frame.fragment_info.unwrap().fragment_id.into())
+        {
+            let mut list = FragmentList::new();
+            list.add_fragment(Fragment {
+                index: frame.fragment_info.unwrap().fragment_index,
+                buffer: frame.body,
+            });
+            list.size = frame.fragment_info.unwrap().fragment_size as u64;
+            self.fragment_table
+                .insert(frame.fragment_info.unwrap().fragment_id.into(), list);
+        } else {
+            self.fragment_table
+                .get_mut(&frame.fragment_info.unwrap().fragment_id.into())
+                .unwrap()
+                .add_fragment(Fragment {
                     index: frame.fragment_info.unwrap().fragment_index,
                     buffer: frame.body,
-               });
-               list.size = frame.fragment_info.unwrap().fragment_size as u64;
-               self.fragment_table
-                    .insert(frame.fragment_info.unwrap().fragment_id.into(), list);
-          } else {
-               self.fragment_table
-                    .get_mut(&frame.fragment_info.unwrap().fragment_id.into())
-                    .unwrap()
-                    .add_fragment(Fragment {
-                         index: frame.fragment_info.unwrap().fragment_index,
-                         buffer: frame.body,
-                    });
-          }
-     }
+                });
+        }
+    }
 
-     pub fn ready(&mut self, index: u16) -> bool {
-          if self.fragment_table.contains_key(&index.into()) {
-               let fragment_list = self.fragment_table.get_mut(&index.into()).unwrap();
-               return fragment_list.fragments.len() as u64 == fragment_list.size;
-          } else {
-               return false;
-          }
-     }
+    pub fn ready(&mut self, index: u16) -> bool {
+        if self.fragment_table.contains_key(&index.into()) {
+            let fragment_list = self.fragment_table.get_mut(&index.into()).unwrap();
+            return fragment_list.fragments.len() as u64 == fragment_list.size;
+        } else {
+            return false;
+        }
+    }
 
-     /// Assembles a FramePacket from the given fragment index
-     /// assuming that all fragments have been sent.
-     pub fn assemble_frame(
-          &mut self,
-          index: u16,
-          size: i16,
-          usable_id: u16,
-     ) -> Option<FramePacket> {
-          if !self.fragment_table.contains_key(&index.into()) {
-               None
-          } else {
-               let assembly = self
-                    .fragment_table
-                    .get_mut(&index.into())
-                    .unwrap()
-                    .assemble(size, usable_id);
-               let mut frame_pk = FramePacket::new();
+    /// Assembles a FramePacket from the given fragment index
+    /// assuming that all fragments have been sent.
+    pub fn assemble_frame(&mut self, index: u16, size: i16, usable_id: u16) -> Option<FramePacket> {
+        if !self.fragment_table.contains_key(&index.into()) {
+            None
+        } else {
+            let assembly = self
+                .fragment_table
+                .get_mut(&index.into())
+                .unwrap()
+                .assemble(size, usable_id);
+            let mut frame_pk = FramePacket::new();
 
-               if assembly.is_some() {
-                    self.fragment_table.remove(&index.into());
+            if assembly.is_some() {
+                self.fragment_table.remove(&index.into());
 
-                    for fpk in assembly.unwrap().into_iter() {
-                         for frame in fpk.frames {
-                              frame_pk.frames.push(frame);
-                         }
+                for fpk in assembly.unwrap().into_iter() {
+                    for frame in fpk.frames {
+                        frame_pk.frames.push(frame);
                     }
+                }
 
-                    Some(frame_pk)
-               } else {
-                    None
-               }
-          }
-     }
+                Some(frame_pk)
+            } else {
+                None
+            }
+        }
+    }
 
-     pub fn has_frame_index(&self, id: u16, index: u16) -> bool {
-          if self.fragment_table.contains_key(&id.into()) {
-               let list = self.fragment_table.get(&id.into()).unwrap();
-               return list.includes(index.into());
-          }
-          false
-     }
+    pub fn has_frame_index(&self, id: u16, index: u16) -> bool {
+        if self.fragment_table.contains_key(&id.into()) {
+            let list = self.fragment_table.get(&id.into()).unwrap();
+            return list.includes(index.into());
+        }
+        false
+    }
 }

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -1,186 +1,198 @@
 pub mod fragment;
 pub mod reliability;
 
-use binary_utils::{self, Streamable, u24::{u24}};
-use std::io::{Cursor, Read, Write};
-use byteorder::{BE, ReadBytesExt, WriteBytesExt};
+use binary_utils::{self, u24::u24, Streamable};
+use byteorder::{ReadBytesExt, WriteBytesExt, BE};
 use fragment::FragmentInfo;
 use reliability::Reliability;
+use std::io::{Cursor, Write};
 
 #[derive(Clone, Debug)]
 pub struct Frame {
-     // This is a triad
-     pub sequence: u64,
-     /// Only if reliable
-     pub reliable_index: Option<u32>,
-     /// Only if sequenced
-     pub sequence_index: Option<u32>,
-     // Order
-     pub order_index: Option<u32>,
-     pub order_channel: Option<u8>,
+    // This is a triad
+    pub sequence: u64,
+    /// Only if reliable
+    pub reliable_index: Option<u32>,
+    /// Only if sequenced
+    pub sequence_index: Option<u32>,
+    // Order
+    pub order_index: Option<u32>,
+    pub order_channel: Option<u8>,
 
-     // fragments
-     pub fragment_info: Option<FragmentInfo>,
+    // fragments
+    pub fragment_info: Option<FragmentInfo>,
 
-     pub flags: u8,
-     pub size: u16,
-     pub reliability: Reliability,
-     pub body: Vec<u8>,
+    pub flags: u8,
+    pub size: u16,
+    pub reliability: Reliability,
+    pub body: Vec<u8>,
 }
 
 impl Frame {
-     /// Creates a dummy frame
-     /// You are expected to update the frame yourself
-     /// this will only create a fake frame instance.
-     pub fn init() -> Self {
-          Self {
-               sequence: 0,
-               reliable_index: None,
-               sequence_index: None,
-               order_index: None,
-               order_channel: None,
-               fragment_info: None,
-               flags: 0,
-               size: 0,
-               reliability: Reliability::from_bit(0),
-               body: Vec::new(),
-          }
-     }
+    /// Creates a dummy frame
+    /// You are expected to update the frame yourself
+    /// this will only create a fake frame instance.
+    pub fn init() -> Self {
+        Self {
+            sequence: 0,
+            reliable_index: None,
+            sequence_index: None,
+            order_index: None,
+            order_channel: None,
+            fragment_info: None,
+            flags: 0,
+            size: 0,
+            reliability: Reliability::from_bit(0),
+            body: Vec::new(),
+        }
+    }
 }
 
 impl Streamable for Frame {
-     fn compose(source: &[u8], position: &mut usize) -> Self {
-          let mut stream = Cursor::new(source.to_vec());
-          let mut frame: Frame = Frame::init();
-          *position = 0;
-          stream.set_position(*position as u64);
-          let flags = stream.read_u8().unwrap();
+    fn compose(source: &[u8], position: &mut usize) -> Self {
+        let mut stream = Cursor::new(source.to_vec());
+        let mut frame: Frame = Frame::init();
+        *position = 0;
+        stream.set_position(*position as u64);
+        let flags = stream.read_u8().unwrap();
 
-          frame.flags = flags;
-          frame.reliability = Reliability::from_bit(flags);
+        frame.flags = flags;
+        frame.reliability = Reliability::from_bit(flags);
 
-          let fragmented = (flags & 0x10) > 0;
-          let bit_length = stream.read_u16::<BE>().unwrap();
+        let fragmented = (flags & 0x10) > 0;
+        let bit_length = stream.read_u16::<BE>().unwrap();
 
-          if Reliability::is_reliable(frame.reliability.to_byte()) {
-               frame.reliable_index = Some(stream.read_u24::<BE>().unwrap().into());
-          }
+        if Reliability::is_reliable(frame.reliability.to_byte()) {
+            frame.reliable_index = Some(stream.read_u24::<BE>().unwrap().into());
+        }
 
-          if Reliability::is_seq(frame.reliability.to_byte()) {
-               frame.sequence_index = Some(stream.read_u24::<BE>().unwrap().into());
-          }
+        if Reliability::is_seq(frame.reliability.to_byte()) {
+            frame.sequence_index = Some(stream.read_u24::<BE>().unwrap().into());
+        }
 
-          if Reliability::is_ord(frame.reliability.to_byte()) {
-               frame.order_index = Some(stream.read_u24::<BE>().unwrap().into());
-               frame.order_channel = Some(stream.read_u8().unwrap());
-          }
+        if Reliability::is_ord(frame.reliability.to_byte()) {
+            frame.order_index = Some(stream.read_u24::<BE>().unwrap().into());
+            frame.order_channel = Some(stream.read_u8().unwrap());
+        }
 
-          if fragmented {
-               frame.fragment_info = Some(FragmentInfo {
-                    fragment_size: stream.read_i32::<BE>().unwrap(),
-                    fragment_id: stream.read_u16::<BE>().unwrap(),
-                    fragment_index: stream.read_i32::<BE>().unwrap(),
-               });
-          }
+        if fragmented {
+            frame.fragment_info = Some(FragmentInfo {
+                fragment_size: stream.read_i32::<BE>().unwrap(),
+                fragment_id: stream.read_u16::<BE>().unwrap(),
+                fragment_index: stream.read_i32::<BE>().unwrap(),
+            });
+        }
 
-          frame.size = bit_length / 8;
+        frame.size = bit_length / 8;
 
-          if source.len() > (frame.size as usize) {
-               // write sized
-               let offset = stream.position() as usize;
-               let inner_buffer = &source[offset..(frame.size as usize) + offset];
-               stream.set_position(stream.position() + (frame.size as u64));
-               frame.body = inner_buffer.to_vec();
-          }
+        if source.len() > (frame.size as usize) {
+            // write sized
+            let offset = stream.position() as usize;
+            let inner_buffer = &source[offset..(frame.size as usize) + offset];
+            stream.set_position(stream.position() + (frame.size as u64));
+            frame.body = inner_buffer.to_vec();
+        }
 
-          frame
-     }
+        frame
+    }
 
-     fn parse(&self) -> Vec<u8> {
-          let mut stream = Cursor::new(Vec::new());
-          let mut flags = self.reliability.to_byte() << 5;
+    fn parse(&self) -> Vec<u8> {
+        let mut stream = Cursor::new(Vec::new());
+        let mut flags = self.reliability.to_byte() << 5;
 
-          if self.fragment_info.is_some() {
-               if self.fragment_info.unwrap().fragment_size > 0 {
-                    flags = flags | 0x10;
-               }
-          }
+        if self.fragment_info.is_some() {
+            if self.fragment_info.unwrap().fragment_size > 0 {
+                flags = flags | 0x10;
+            }
+        }
 
-          stream.write_u8(flags).unwrap();
-          stream.write_u16::<BE>((self.body.len() as u16) * 8).unwrap();
+        stream.write_u8(flags).unwrap();
+        stream
+            .write_u16::<BE>((self.body.len() as u16) * 8)
+            .unwrap();
 
-          if self.reliable_index.is_some() {
-               stream.write_u24::<BE>(self.reliable_index.unwrap()).unwrap();
-          }
+        if self.reliable_index.is_some() {
+            stream
+                .write_u24::<BE>(self.reliable_index.unwrap())
+                .unwrap();
+        }
 
-          if self.sequence_index.is_some() {
-               stream.write_u24::<BE>(self.sequence_index.unwrap()).unwrap();
-          }
+        if self.sequence_index.is_some() {
+            stream
+                .write_u24::<BE>(self.sequence_index.unwrap())
+                .unwrap();
+        }
 
-          if self.order_index.is_some() {
-               stream.write_u24::<BE>(self.order_index.unwrap()).unwrap();
-               stream.write_u8(self.order_channel.unwrap()).unwrap();
-          }
+        if self.order_index.is_some() {
+            stream.write_u24::<BE>(self.order_index.unwrap()).unwrap();
+            stream.write_u8(self.order_channel.unwrap()).unwrap();
+        }
 
-          if self.fragment_info.is_some() {
-               if self.fragment_info.unwrap().fragment_size > 0 {
-                    stream.write_i32::<BE>(self.fragment_info.unwrap().fragment_size).unwrap();
-                    stream.write_u16::<BE>(self.fragment_info.unwrap().fragment_id).unwrap();
-                    stream.write_i32::<BE>(self.fragment_info.unwrap().fragment_index).unwrap();
-               }
-          }
+        if self.fragment_info.is_some() {
+            if self.fragment_info.unwrap().fragment_size > 0 {
+                stream
+                    .write_i32::<BE>(self.fragment_info.unwrap().fragment_size)
+                    .unwrap();
+                stream
+                    .write_u16::<BE>(self.fragment_info.unwrap().fragment_id)
+                    .unwrap();
+                stream
+                    .write_i32::<BE>(self.fragment_info.unwrap().fragment_index)
+                    .unwrap();
+            }
+        }
 
-          stream.write_all(&self.body).unwrap();
-          stream.get_ref().clone()
-     }
+        stream.write_all(&self.body).unwrap();
+        stream.get_ref().clone()
+    }
 }
 #[derive(Debug)]
 pub struct FramePacket {
-     pub seq: u24,
-     pub frames: Vec<Frame>,
+    pub seq: u24,
+    pub frames: Vec<Frame>,
 }
 
 impl FramePacket {
-     pub fn new() -> Self {
-          Self {
-               seq: 0.into(),
-               frames: Vec::new(),
-          }
-     }
+    pub fn new() -> Self {
+        Self {
+            seq: 0.into(),
+            frames: Vec::new(),
+        }
+    }
 }
 
 impl Streamable for FramePacket {
-     fn parse(&self) -> Vec<u8> {
-          let mut stream = Vec::new();
-          stream.write_u8(0x80).unwrap();
-          stream.write_u24::<BE>(self.seq.into()).unwrap();
+    fn parse(&self) -> Vec<u8> {
+        let mut stream = Vec::new();
+        stream.write_u8(0x80).unwrap();
+        stream.write_u24::<BE>(self.seq.into()).unwrap();
 
-          for f in self.frames.iter() {
-               stream.write_all(&f.parse()).unwrap();
-          }
-          stream
-     }
+        for f in self.frames.iter() {
+            stream.write_all(&f.parse()).unwrap();
+        }
+        stream
+    }
 
-     fn compose(source: &[u8], position: &mut usize) -> Self {
-          let mut packet = FramePacket::new();
-          let mut stream = Cursor::new(source);
-          stream.set_position(*position as u64);
-          packet.seq = stream.read_u24::<BE>().unwrap().into();
+    fn compose(source: &[u8], position: &mut usize) -> Self {
+        let mut packet = FramePacket::new();
+        let mut stream = Cursor::new(source);
+        stream.set_position(*position as u64);
+        packet.seq = stream.read_u24::<BE>().unwrap().into();
 
-          loop {
-               if stream.position() >= source.len() as u64 {
-                    return packet;
-               }
+        loop {
+            if stream.position() >= source.len() as u64 {
+                return packet;
+            }
 
-               let offset: usize = stream.position() as usize;
-               let frm = Frame::compose(&source[(offset)..], &mut 0);
-               stream.set_position(source.len() as u64);
-               packet.frames.push(frm.clone());
-               if frm.parse().len() + stream.position() as usize >= source.len() {
-                    return packet;
-               } else {
-                    stream.set_position(frm.parse().len() as u64);
-               }
-          }
-     }
+            let offset: usize = stream.position() as usize;
+            let frm = Frame::compose(&source[(offset)..], &mut 0);
+            stream.set_position(source.len() as u64);
+            packet.frames.push(frm.clone());
+            if frm.parse().len() + stream.position() as usize >= source.len() {
+                return packet;
+            } else {
+                stream.set_position(frm.parse().len() as u64);
+            }
+        }
+    }
 }

--- a/src/frame/reliability.rs
+++ b/src/frame/reliability.rs
@@ -1,76 +1,76 @@
 #[derive(Clone, Debug)]
 pub struct Reliability {
-     flag: ReliabilityFlag,
+    flag: ReliabilityFlag,
 }
 
 impl Reliability {
-     pub fn new(flag: ReliabilityFlag) -> Self {
-          Self { flag }
-     }
+    pub fn new(flag: ReliabilityFlag) -> Self {
+        Self { flag }
+    }
 
-     pub fn from_bit(byte: u8) -> Self {
-          match (byte & 224) >> 5 {
-               0 => Self::new(ReliabilityFlag::Unreliable),
-               1 => Self::new(ReliabilityFlag::UnreliableSeq),
-               2 => Self::new(ReliabilityFlag::Reliable),
-               3 => Self::new(ReliabilityFlag::ReliableOrd),
-               4 => Self::new(ReliabilityFlag::ReliableSeq),
-               5 => Self::new(ReliabilityFlag::UnreliableAck),
-               6 => Self::new(ReliabilityFlag::ReliableAck),
-               7 => Self::new(ReliabilityFlag::ReliableOrdAck),
-               _ => Self::new(ReliabilityFlag::Unreliable),
-          }
-     }
+    pub fn from_bit(byte: u8) -> Self {
+        match (byte & 224) >> 5 {
+            0 => Self::new(ReliabilityFlag::Unreliable),
+            1 => Self::new(ReliabilityFlag::UnreliableSeq),
+            2 => Self::new(ReliabilityFlag::Reliable),
+            3 => Self::new(ReliabilityFlag::ReliableOrd),
+            4 => Self::new(ReliabilityFlag::ReliableSeq),
+            5 => Self::new(ReliabilityFlag::UnreliableAck),
+            6 => Self::new(ReliabilityFlag::ReliableAck),
+            7 => Self::new(ReliabilityFlag::ReliableOrdAck),
+            _ => Self::new(ReliabilityFlag::Unreliable),
+        }
+    }
 
-     pub fn to_byte(&self) -> u8 {
-          match self.flag {
-               ReliabilityFlag::Unreliable => 0,
-               ReliabilityFlag::UnreliableSeq => 1,
-               ReliabilityFlag::Reliable => 2,
-               ReliabilityFlag::ReliableOrd => 3,
-               ReliabilityFlag::ReliableSeq => 4,
-               ReliabilityFlag::UnreliableAck => 5,
-               ReliabilityFlag::ReliableAck => 6,
-               ReliabilityFlag::ReliableOrdAck => 7,
-          }
-     }
+    pub fn to_byte(&self) -> u8 {
+        match self.flag {
+            ReliabilityFlag::Unreliable => 0,
+            ReliabilityFlag::UnreliableSeq => 1,
+            ReliabilityFlag::Reliable => 2,
+            ReliabilityFlag::ReliableOrd => 3,
+            ReliabilityFlag::ReliableSeq => 4,
+            ReliabilityFlag::UnreliableAck => 5,
+            ReliabilityFlag::ReliableAck => 6,
+            ReliabilityFlag::ReliableOrdAck => 7,
+        }
+    }
 
-     pub fn is_reliable(byte: u8) -> bool {
-          match byte {
-               2 | 3 | 4 => true,
-               6 | 7 => true,
-               _ => false,
-          }
-     }
+    pub fn is_reliable(byte: u8) -> bool {
+        match byte {
+            2 | 3 | 4 => true,
+            6 | 7 => true,
+            _ => false,
+        }
+    }
 
-     pub fn is_seq(byte: u8) -> bool {
-          match byte {
-               1 | 4 => true,
-               _ => false,
-          }
-     }
+    pub fn is_seq(byte: u8) -> bool {
+        match byte {
+            1 | 4 => true,
+            _ => false,
+        }
+    }
 
-     pub fn is_ord(byte: u8) -> bool {
-          if Self::is_seq(byte) {
-               return true;
-          }
-          match byte {
-               3 | 7 => true,
-               _ => false,
-          }
-     }
+    pub fn is_ord(byte: u8) -> bool {
+        if Self::is_seq(byte) {
+            return true;
+        }
+        match byte {
+            3 | 7 => true,
+            _ => false,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
 pub enum ReliabilityFlag {
-     Unreliable,
-     UnreliableSeq,
-     Reliable,
-     ReliableOrd,
-     ReliableSeq,
-     UnreliableAck,
-     ReliableAck,
-     ReliableOrdAck,
+    Unreliable,
+    UnreliableSeq,
+    Reliable,
+    ReliableOrd,
+    ReliableSeq,
+    UnreliableAck,
+    ReliableAck,
+    ReliableOrdAck,
 }
 
 impl ReliabilityFlag {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(cursor_remaining)]
-#[macro_use]
 extern crate binary_utils;
 
 pub mod ack;
@@ -16,6 +15,14 @@ pub const SERVER_ID: i64 = 2747994720109207718; //rand::random::<i64>();
 pub const USE_SECURITY: bool = false;
 
 pub use self::{frame::*, protocol::*, server::*, util::*};
+
+#[macro_export]
+macro_rules! raknet_start {
+    ($server: expr, $fn: expr) => {
+        // Simple hack to make "serv" a mutable var const
+        $server.start(Box::new($fn))
+    };
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,65 +1,63 @@
 use crate::SERVER_ID;
-use binary_utils::*;
 use std::io::Cursor;
 pub mod offline;
 pub mod online;
 
-
 pub struct Packet {
-     pub stream: Cursor<Vec<u8>>,
-     pub id: u16,
+    pub stream: Cursor<Vec<u8>>,
+    pub id: u16,
 }
 
 #[derive(Clone, Debug)]
 pub struct Motd {
-     pub name: String,
-     pub protocol: u16,
-     pub version: String,
-     pub player_count: u16,
-     pub player_max: u16,
-     pub gamemode: String,
-     pub server_id: i64,
+    pub name: String,
+    pub protocol: u16,
+    pub version: String,
+    pub player_count: u16,
+    pub player_max: u16,
+    pub gamemode: String,
+    pub server_id: i64,
 }
 
 impl Motd {
-     pub fn default() -> Self {
-          Self {
-               name: String::from("Netrex Server"),
-               player_count: 10,
-               player_max: 100,
-               protocol: 448,
-               gamemode: String::from("Creative"),
-               version: String::from("1.17.10"),
-               server_id: SERVER_ID,
-          }
-     }
+    pub fn default() -> Self {
+        Self {
+            name: String::from("Netrex Server"),
+            player_count: 10,
+            player_max: 100,
+            protocol: 448,
+            gamemode: String::from("Creative"),
+            version: String::from("1.17.10"),
+            server_id: SERVER_ID,
+        }
+    }
 
-     pub fn encode(&self) -> String {
-          let mut parsed = String::new();
-          let prot = self.protocol.to_string();
-          let pcount = self.player_count.to_string();
-          let pmax = self.player_max.to_string();
-          let server_id = SERVER_ID.to_string();
-          let props = vec![
-               "MCPE",
-               self.name.as_str(),
-               prot.as_str(),
-               self.version.as_str(),
-               pcount.as_str(),
-               pmax.as_str(),
-               server_id.as_str(),
-               "Netrex",
-               self.gamemode.as_str(),
-               "1",
-               "19132",
-               "19133",
-          ];
+    pub fn encode(&self) -> String {
+        let mut parsed = String::new();
+        let prot = self.protocol.to_string();
+        let pcount = self.player_count.to_string();
+        let pmax = self.player_max.to_string();
+        let server_id = SERVER_ID.to_string();
+        let props = vec![
+            "MCPE",
+            self.name.as_str(),
+            prot.as_str(),
+            self.version.as_str(),
+            pcount.as_str(),
+            pmax.as_str(),
+            server_id.as_str(),
+            "Netrex",
+            self.gamemode.as_str(),
+            "1",
+            "19132",
+            "19133",
+        ];
 
-          for prop in props.iter() {
-               parsed.push_str(prop);
-               parsed.push(';');
-          }
+        for prop in props.iter() {
+            parsed.push_str(prop);
+            parsed.push(';');
+        }
 
-          parsed
-     }
+        parsed
+    }
 }

--- a/src/protocol/offline.rs
+++ b/src/protocol/offline.rs
@@ -1,115 +1,114 @@
 #![allow(dead_code)]
 
 use crate::conn::{Connection, ConnectionState};
-use crate::{IPacketStreamRead, IPacketStreamWrite, Magic, RakNetVersion, USE_SECURITY};
-use crate::{Motd, SERVER_ID};
-use crate::RakNetEvent;
+use crate::{Magic, RakNetVersion, SERVER_ID, USE_SECURITY};
 use binary_utils::*;
-use byteorder::{ReadBytesExt, WriteBytesExt};
-use std::convert::TryInto;
+use byteorder::WriteBytesExt;
 use std::fmt::{Formatter, Result as FResult};
+use std::io::Write;
 use std::net::SocketAddr;
-use std::io::{Cursor, Write};
 
 pub enum OfflinePackets {
-     UnconnectedPing,
-     OpenConnectRequest,
-     OpenConnectReply,
-     SessionInfoRequest,
-     SessionInfoReply,
-     UnconnectedPong,
-     IncompatibleProtocolVersion,
-     UnknownPacket(u8),
+    UnconnectedPing,
+    OpenConnectRequest,
+    OpenConnectReply,
+    SessionInfoRequest,
+    SessionInfoReply,
+    UnconnectedPong,
+    IncompatibleProtocolVersion,
+    UnknownPacket(u8),
 }
 
 impl OfflinePackets {
-     pub fn recv(byte: u8) -> Self {
-          match byte {
-               0x01 => OfflinePackets::UnconnectedPing,
-               0x05 => OfflinePackets::OpenConnectRequest,
-               0x06 => OfflinePackets::OpenConnectReply,
-               0x07 => OfflinePackets::SessionInfoRequest,
-               0x08 => OfflinePackets::SessionInfoReply,
-               0x1c => OfflinePackets::UnconnectedPong,
-               0x19 => OfflinePackets::IncompatibleProtocolVersion,
-               _ => OfflinePackets::UnknownPacket(byte),
-          }
-     }
+    pub fn recv(byte: u8) -> Self {
+        match byte {
+            0x01 => OfflinePackets::UnconnectedPing,
+            0x05 => OfflinePackets::OpenConnectRequest,
+            0x06 => OfflinePackets::OpenConnectReply,
+            0x07 => OfflinePackets::SessionInfoRequest,
+            0x08 => OfflinePackets::SessionInfoReply,
+            0x1c => OfflinePackets::UnconnectedPong,
+            0x19 => OfflinePackets::IncompatibleProtocolVersion,
+            _ => OfflinePackets::UnknownPacket(byte),
+        }
+    }
 
-     pub fn to_byte(&self) -> u8 {
-          match *self {
-               OfflinePackets::UnconnectedPing => 0x01,
-               OfflinePackets::OpenConnectRequest => 0x05,
-               OfflinePackets::OpenConnectReply => 0x06,
-               OfflinePackets::SessionInfoRequest => 0x07,
-               OfflinePackets::SessionInfoReply => 0x08,
-               OfflinePackets::UnconnectedPong => 0x1c,
-               OfflinePackets::IncompatibleProtocolVersion => 0x19,
-               OfflinePackets::UnknownPacket(byte) => byte,
-          }
-     }
+    pub fn to_byte(&self) -> u8 {
+        match *self {
+            OfflinePackets::UnconnectedPing => 0x01,
+            OfflinePackets::OpenConnectRequest => 0x05,
+            OfflinePackets::OpenConnectReply => 0x06,
+            OfflinePackets::SessionInfoRequest => 0x07,
+            OfflinePackets::SessionInfoReply => 0x08,
+            OfflinePackets::UnconnectedPong => 0x1c,
+            OfflinePackets::IncompatibleProtocolVersion => 0x19,
+            OfflinePackets::UnknownPacket(byte) => byte,
+        }
+    }
 }
 
 impl std::fmt::Display for OfflinePackets {
-     fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-          match *self {
-               OfflinePackets::UnconnectedPing => write!(f, "{}", self.to_byte()),
-               OfflinePackets::OpenConnectRequest => write!(f, "{}", self.to_byte()),
-               OfflinePackets::OpenConnectReply => write!(f, "{}", self.to_byte()),
-               OfflinePackets::SessionInfoRequest => write!(f, "{}", self.to_byte()),
-               OfflinePackets::SessionInfoReply => write!(f, "{}", self.to_byte()),
-               OfflinePackets::UnconnectedPong => write!(f, "{}", self.to_byte()),
-               OfflinePackets::IncompatibleProtocolVersion => write!(f, "{}", self.to_byte()),
-               OfflinePackets::UnknownPacket(byte) => write!(f, "{}", byte),
-          }
-     }
+    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
+        match *self {
+            OfflinePackets::UnconnectedPing => write!(f, "{}", self.to_byte()),
+            OfflinePackets::OpenConnectRequest => write!(f, "{}", self.to_byte()),
+            OfflinePackets::OpenConnectReply => write!(f, "{}", self.to_byte()),
+            OfflinePackets::SessionInfoRequest => write!(f, "{}", self.to_byte()),
+            OfflinePackets::SessionInfoReply => write!(f, "{}", self.to_byte()),
+            OfflinePackets::UnconnectedPong => write!(f, "{}", self.to_byte()),
+            OfflinePackets::IncompatibleProtocolVersion => write!(f, "{}", self.to_byte()),
+            OfflinePackets::UnknownPacket(byte) => write!(f, "{}", byte),
+        }
+    }
 }
 
 /// Unconnected Ping
 #[derive(Debug, BinaryStream)]
 pub struct UnconnectedPing {
-     timestamp: i64,
-     magic: Magic,
-     client_id: i64,
+    timestamp: i64,
+    magic: Magic,
+    client_id: i64,
 }
 
 /// Unconnected Pong
 #[derive(Debug, BinaryStream)]
 pub struct UnconnectedPong {
-     id: u8,
-     timestamp: i64,
-     server_id: i64,
-     magic: Magic,
-     motd: String,
+    id: u8,
+    timestamp: i64,
+    server_id: i64,
+    magic: Magic,
+    motd: String,
 }
 
 /// A connection request recv the client.
 #[derive(Debug)]
 pub struct OpenConnectRequest {
-     magic: Magic,
-     protocol: u8,
-     mtu_size: u16,
+    magic: Magic,
+    protocol: u8,
+    mtu_size: u16,
 }
 
 impl Streamable for OpenConnectRequest {
-     fn compose(source: &[u8], position: &mut usize) -> Self {
-          Self {
-               magic: Magic::compose(source, position),
-               protocol: u8::compose(source, position),
-               mtu_size: (source.len() + 1 + 28) as u16
-          }
-     }
+    fn compose(source: &[u8], position: &mut usize) -> Self {
+        Self {
+            magic: Magic::compose(source, position),
+            protocol: u8::compose(source, position),
+            mtu_size: (source.len() + 1 + 28) as u16,
+        }
+    }
 
-     fn parse(&self) -> Vec<u8> {
-         let mut stream = Vec::<u8>::new();
-         stream.write(&self.magic.parse()[..]);
-         stream.write_u8(self.protocol).unwrap();
-         // padding
-         for x in 0..self.mtu_size {
-              stream.write_u8(0).unwrap();
-         }
-         stream
-     }
+    fn parse(&self) -> Vec<u8> {
+        let mut stream = Vec::<u8>::new();
+        stream
+            .write(&self.magic.parse()[..])
+            .expect("Failed to parse open connect request");
+        stream.write_u8(self.protocol).unwrap();
+        // padding
+        for _ in 0..self.mtu_size {
+            stream.write_u8(0).unwrap();
+        }
+        stream
+    }
 }
 
 // Mtu size may be needed here.
@@ -130,95 +129,95 @@ impl Streamable for OpenConnectRequest {
 /// Sent to the client when the server accepts a client.
 #[derive(Debug, BinaryStream)]
 pub struct OpenConnectReply {
-     id: u8,
-     magic: Magic,
-     server_id: i64,
-     security: bool,
-     mtu_size: u16,
+    id: u8,
+    magic: Magic,
+    server_id: i64,
+    security: bool,
+    mtu_size: u16,
 }
 /// Session info, also known as Open Connect Request 2
 #[derive(Debug, BinaryStream)]
 pub struct SessionInfoRequest {
-     magic: Magic,
-     address: SocketAddr,
-     mtu_size: i16,
-     client_id: i64,
+    magic: Magic,
+    address: SocketAddr,
+    mtu_size: i16,
+    client_id: i64,
 }
 
 /// Session Info Reply, also known as Open Connect Reply 2
 #[derive(Debug, BinaryStream)]
 pub struct SessionInfoReply {
-     id: u8,
-     magic: Magic,
-     server_id: i64,
-     client_address: SocketAddr,
-     mtu_size: i16,
-     security: bool,
+    id: u8,
+    magic: Magic,
+    server_id: i64,
+    client_address: SocketAddr,
+    mtu_size: i16,
+    security: bool,
 }
 
 #[derive(Debug, BinaryStream)]
 pub struct IncompatibleProtocolVersion {
-     id: u8,
-     protocol: u8,
-     magic: Magic,
-     server_id: i64,
+    id: u8,
+    protocol: u8,
+    magic: Magic,
+    server_id: i64,
 }
 
 pub fn handle_offline(
-     connection: &mut Connection,
-     pk: OfflinePackets,
-     stream: &mut &Vec<u8>,
+    connection: &mut Connection,
+    pk: OfflinePackets,
+    stream: &mut &Vec<u8>,
 ) -> Vec<u8> {
-     match pk {
-          OfflinePackets::UnconnectedPing => {
-               let pong = UnconnectedPong {
-                    id: OfflinePackets::UnconnectedPong.to_byte(),
-                    server_id: SERVER_ID,
-                    timestamp: connection.time.elapsed().unwrap().as_millis() as i64,
+    match pk {
+        OfflinePackets::UnconnectedPing => {
+            let pong = UnconnectedPong {
+                id: OfflinePackets::UnconnectedPong.to_byte(),
+                server_id: SERVER_ID,
+                timestamp: connection.time.elapsed().unwrap().as_millis() as i64,
+                magic: Magic::new(),
+                motd: connection.get_motd().encode(),
+            };
+            pong.parse()
+        }
+        OfflinePackets::OpenConnectRequest => {
+            let request = OpenConnectRequest::compose(&stream[..], &mut 1);
+
+            if request.protocol != RakNetVersion::MinecraftRecent.to_u8() {
+                let incompatible = IncompatibleProtocolVersion {
+                    id: OfflinePackets::IncompatibleProtocolVersion.to_byte(),
+                    protocol: request.protocol,
                     magic: Magic::new(),
-                    motd: connection.get_motd().encode(),
-               };
-               pong.parse()
-          }
-          OfflinePackets::OpenConnectRequest => {
-               let request = OpenConnectRequest::compose(&stream[..], &mut 1);
-
-               if request.protocol != RakNetVersion::MinecraftRecent.to_u8() {
-                    let incompatible = IncompatibleProtocolVersion {
-                         id: OfflinePackets::IncompatibleProtocolVersion.to_byte(),
-                         protocol: request.protocol,
-                         magic: Magic::new(),
-                         server_id: SERVER_ID,
-                    };
-
-                    return incompatible.parse();
-               }
-
-               let reply = OpenConnectReply {
-                    id: OfflinePackets::OpenConnectReply.to_byte(),
                     server_id: SERVER_ID,
-                    security: USE_SECURITY,
-                    magic: Magic::new(),
-                    mtu_size: request.mtu_size,
-               };
+                };
 
-               reply.parse()
-          }
-          OfflinePackets::SessionInfoRequest => {
-               let request = SessionInfoRequest::compose(&stream[..], &mut 1);
-               let reply = SessionInfoReply {
-                    id: OfflinePackets::SessionInfoReply.to_byte(),
-                    server_id: SERVER_ID,
-                    client_address: connection.address.clone(),
-                    magic: Magic::new(),
-                    mtu_size: request.mtu_size,
-                    security: USE_SECURITY,
-               };
+                return incompatible.parse();
+            }
 
-               connection.mtu_size = request.mtu_size as u16;
-               connection.state = ConnectionState::Connecting;
-               reply.parse()
-          }
-          _ => Vec::new(), //TODO: Throw an UnknownPacket here rather than sending an empty binary stream
-     }
+            let reply = OpenConnectReply {
+                id: OfflinePackets::OpenConnectReply.to_byte(),
+                server_id: SERVER_ID,
+                security: USE_SECURITY,
+                magic: Magic::new(),
+                mtu_size: request.mtu_size,
+            };
+
+            reply.parse()
+        }
+        OfflinePackets::SessionInfoRequest => {
+            let request = SessionInfoRequest::compose(&stream[..], &mut 1);
+            let reply = SessionInfoReply {
+                id: OfflinePackets::SessionInfoReply.to_byte(),
+                server_id: SERVER_ID,
+                client_address: connection.address.clone(),
+                magic: Magic::new(),
+                mtu_size: request.mtu_size,
+                security: USE_SECURITY,
+            };
+
+            connection.mtu_size = request.mtu_size as u16;
+            connection.state = ConnectionState::Connecting;
+            reply.parse()
+        }
+        _ => Vec::new(), //TODO: Throw an UnknownPacket here rather than sending an empty binary stream
+    }
 }

--- a/src/protocol/online.rs
+++ b/src/protocol/online.rs
@@ -3,175 +3,172 @@ use crate::conn::{Connection, ConnectionState};
 use crate::util::tokenize_addr;
 use crate::RakNetEvent;
 use binary_utils::*;
-use byteorder::{ReadBytesExt, WriteBytesExt, BigEndian};
-use std::io::{Read, Write};
+use byteorder::{BigEndian, WriteBytesExt};
 use std::fmt::{Formatter, Result as FResult};
+use std::io::Write;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::SystemTime;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum OnlinePackets {
-     ConnectedPing,
-     ConnectedPong,
-     ConnectionRequest,
-     ConnectionAccept,
-     GamePacket,
-     FramePacket(u8),
-     NewConnection,
-     Disconnect,
-     UnknownPacket(u8),
+    ConnectedPing,
+    ConnectedPong,
+    ConnectionRequest,
+    ConnectionAccept,
+    GamePacket,
+    FramePacket(u8),
+    NewConnection,
+    Disconnect,
+    UnknownPacket(u8),
 }
 
 impl OnlinePackets {
-     pub fn recv(byte: u8) -> Self {
-          match byte {
-               0x00 => OnlinePackets::ConnectedPing,
-               0x03 => OnlinePackets::ConnectedPong,
-               0x09 => OnlinePackets::ConnectionRequest,
-               0x10 => OnlinePackets::ConnectionAccept,
-               0x13 => OnlinePackets::NewConnection,
-               0x15 => OnlinePackets::Disconnect,
-               0xfe => OnlinePackets::GamePacket,
-               0x80..=0x8d => OnlinePackets::FramePacket(byte),
-               _ => OnlinePackets::UnknownPacket(byte),
-          }
-     }
+    pub fn recv(byte: u8) -> Self {
+        match byte {
+            0x00 => OnlinePackets::ConnectedPing,
+            0x03 => OnlinePackets::ConnectedPong,
+            0x09 => OnlinePackets::ConnectionRequest,
+            0x10 => OnlinePackets::ConnectionAccept,
+            0x13 => OnlinePackets::NewConnection,
+            0x15 => OnlinePackets::Disconnect,
+            0xfe => OnlinePackets::GamePacket,
+            0x80..=0x8d => OnlinePackets::FramePacket(byte),
+            _ => OnlinePackets::UnknownPacket(byte),
+        }
+    }
 
-     pub fn to_byte(&self) -> u8 {
-          match *self {
-               OnlinePackets::ConnectedPing => 0x00,
-               OnlinePackets::ConnectedPong => 0x03,
-               OnlinePackets::ConnectionRequest => 0x09,
-               OnlinePackets::ConnectionAccept => 0x10,
-               OnlinePackets::NewConnection => 0x13,
-               OnlinePackets::Disconnect => 0x15,
-               OnlinePackets::GamePacket => 0xfe,
-               OnlinePackets::FramePacket(b) => b,
-               OnlinePackets::UnknownPacket(byte) => byte,
-          }
-     }
+    pub fn to_byte(&self) -> u8 {
+        match *self {
+            OnlinePackets::ConnectedPing => 0x00,
+            OnlinePackets::ConnectedPong => 0x03,
+            OnlinePackets::ConnectionRequest => 0x09,
+            OnlinePackets::ConnectionAccept => 0x10,
+            OnlinePackets::NewConnection => 0x13,
+            OnlinePackets::Disconnect => 0x15,
+            OnlinePackets::GamePacket => 0xfe,
+            OnlinePackets::FramePacket(b) => b,
+            OnlinePackets::UnknownPacket(byte) => byte,
+        }
+    }
 }
 
 impl std::fmt::Display for OnlinePackets {
-     fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
-          match *self {
-               OnlinePackets::ConnectedPing => write!(f, "{}", self.to_byte()),
-               OnlinePackets::ConnectedPong => write!(f, "{}", self.to_byte()),
-               OnlinePackets::ConnectionRequest => write!(f, "{}", self.to_byte()),
-               OnlinePackets::ConnectionAccept => write!(f, "{}", self.to_byte()),
-               OnlinePackets::NewConnection => write!(f, "{}", self.to_byte()),
-               OnlinePackets::Disconnect => write!(f, "{}", self.to_byte()),
-               OnlinePackets::GamePacket => write!(f, "{}", self.to_byte()),
-               OnlinePackets::UnknownPacket(byte) => write!(f, "{}", byte),
-               OnlinePackets::FramePacket(byte) => write!(f, "{}", byte),
-          }
-     }
+    fn fmt(&self, f: &mut Formatter<'_>) -> FResult {
+        match *self {
+            OnlinePackets::ConnectedPing => write!(f, "{}", self.to_byte()),
+            OnlinePackets::ConnectedPong => write!(f, "{}", self.to_byte()),
+            OnlinePackets::ConnectionRequest => write!(f, "{}", self.to_byte()),
+            OnlinePackets::ConnectionAccept => write!(f, "{}", self.to_byte()),
+            OnlinePackets::NewConnection => write!(f, "{}", self.to_byte()),
+            OnlinePackets::Disconnect => write!(f, "{}", self.to_byte()),
+            OnlinePackets::GamePacket => write!(f, "{}", self.to_byte()),
+            OnlinePackets::UnknownPacket(byte) => write!(f, "{}", byte),
+            OnlinePackets::FramePacket(byte) => write!(f, "{}", byte),
+        }
+    }
 }
 
 #[derive(Debug, BinaryStream)]
 pub struct ConnectionRequest {
-     client_id: i64,
-     timestamp: i64,
+    client_id: i64,
+    timestamp: i64,
 }
 
 #[derive(Debug)]
 pub struct ConnectionAccept {
-     id: u8,
-     client_address: SocketAddr,
-     system_index: i16,
-     internal_ids: SocketAddr,
-     request_time: i64,
-     timestamp: i64,
+    id: u8,
+    client_address: SocketAddr,
+    system_index: i16,
+    internal_ids: SocketAddr,
+    request_time: i64,
+    timestamp: i64,
 }
 
 impl Streamable for ConnectionAccept {
-     fn parse(&self) -> Vec<u8> {
-         let mut stream = Vec::new();
-         stream.write_u8(self.id).unwrap();
-         stream.write_all(&self.client_address.parse()[..]).unwrap();
-         stream.write_i16::<BigEndian>(self.system_index).unwrap();
-         for _ in 0..10 {
-              stream.write_all(&self.internal_ids.parse()[..]).unwrap();
-         }
-         stream.write_i64::<BigEndian>(self.request_time).unwrap();
-         stream.write_i64::<BigEndian>(self.timestamp).unwrap();
-         stream
-     }
+    fn parse(&self) -> Vec<u8> {
+        let mut stream = Vec::new();
+        stream.write_u8(self.id).unwrap();
+        stream.write_all(&self.client_address.parse()[..]).unwrap();
+        stream.write_i16::<BigEndian>(self.system_index).unwrap();
+        for _ in 0..10 {
+            stream.write_all(&self.internal_ids.parse()[..]).unwrap();
+        }
+        stream.write_i64::<BigEndian>(self.request_time).unwrap();
+        stream.write_i64::<BigEndian>(self.timestamp).unwrap();
+        stream
+    }
 
-     fn compose(_source: &[u8], _position: &mut usize) -> Self {
-          Self {
-               id: 0,
-               client_address: SocketAddr::new(IpAddr::from(Ipv4Addr::new(192,168,0,1)), 9120),
-               system_index: 0,
-               internal_ids: SocketAddr::new(IpAddr::from(Ipv4Addr::new(127,0,0,1)), 1920),
-               request_time: 0,
-               timestamp: 0
-          }
-     }
+    fn compose(_source: &[u8], _position: &mut usize) -> Self {
+        Self {
+            id: 0,
+            client_address: SocketAddr::new(IpAddr::from(Ipv4Addr::new(192, 168, 0, 1)), 9120),
+            system_index: 0,
+            internal_ids: SocketAddr::new(IpAddr::from(Ipv4Addr::new(127, 0, 0, 1)), 1920),
+            request_time: 0,
+            timestamp: 0,
+        }
+    }
 }
 
 #[derive(Debug, BinaryStream)]
 pub struct ConnectedPing {
-     time: i64,
+    time: i64,
 }
 
 #[derive(Debug, BinaryStream)]
 pub struct ConnectedPong {
-     id: u8,
-     ping_time: i64,
-     pong_time: i64,
+    id: u8,
+    ping_time: i64,
+    pong_time: i64,
 }
 
 pub fn handle_online(
-     connection: &mut Connection,
-     pk: OnlinePackets,
-     stream: &mut Vec<u8>,
+    connection: &mut Connection,
+    pk: OnlinePackets,
+    stream: &mut Vec<u8>,
 ) -> Vec<u8> {
-     match pk {
-          OnlinePackets::ConnectionRequest => {
-               let request = ConnectionRequest::compose(stream, &mut 1);
-               let accept = ConnectionAccept {
-                    id: OnlinePackets::ConnectionAccept.to_byte(),
-                    client_address: connection.address.clone(),
-                    system_index: 0,
-                    internal_ids: SocketAddr::new(
-                         IpAddr::V4(Ipv4Addr::new(255, 255, 255, 255)),
-                         19132,
-                    ),
-                    request_time: request.timestamp,
-                    timestamp: SystemTime::now()
-                         .duration_since(connection.time)
-                         .unwrap()
-                         .as_millis() as i64,
-               };
-               connection.state = ConnectionState::Connected;
-               accept.parse()
-          }
-          OnlinePackets::Disconnect => {
-               connection.state = ConnectionState::Offline;
-               connection.event_dispatch.push_back(RakNetEvent::Disconnect(
-                    tokenize_addr(connection.address),
-                    "Client disconnect".to_owned(),
-               ));
-               Vec::new()
-          }
-          OnlinePackets::NewConnection => Vec::new(),
-          OnlinePackets::ConnectedPing => {
-               let request = ConnectedPing::compose(stream, &mut 0);
-               let pong = ConnectedPong {
-                    id: OnlinePackets::ConnectedPong.to_byte(),
-                    ping_time: request.time,
-                    pong_time: SystemTime::now()
-                         .duration_since(connection.time)
-                         .unwrap()
-                         .as_millis() as i64,
-               };
-               pong.parse()
-          }
-          OnlinePackets::FramePacket(_v) => {
-               println!("Condition should never be met.");
-               Vec::new()
-          }
-          _ => Vec::new(), // TODO: Throw an UnknownPacket here rather than sending an empty binary stream
-     }
+    match pk {
+        OnlinePackets::ConnectionRequest => {
+            let request = ConnectionRequest::compose(stream, &mut 1);
+            let accept = ConnectionAccept {
+                id: OnlinePackets::ConnectionAccept.to_byte(),
+                client_address: connection.address.clone(),
+                system_index: 0,
+                internal_ids: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(255, 255, 255, 255)), 19132),
+                request_time: request.timestamp,
+                timestamp: SystemTime::now()
+                    .duration_since(connection.time)
+                    .unwrap()
+                    .as_millis() as i64,
+            };
+            connection.state = ConnectionState::Connected;
+            accept.parse()
+        }
+        OnlinePackets::Disconnect => {
+            connection.state = ConnectionState::Offline;
+            connection.event_dispatch.push_back(RakNetEvent::Disconnect(
+                tokenize_addr(connection.address),
+                "Client disconnect".to_owned(),
+            ));
+            Vec::new()
+        }
+        OnlinePackets::NewConnection => Vec::new(),
+        OnlinePackets::ConnectedPing => {
+            let request = ConnectedPing::compose(stream, &mut 0);
+            let pong = ConnectedPong {
+                id: OnlinePackets::ConnectedPong.to_byte(),
+                ping_time: request.time,
+                pong_time: SystemTime::now()
+                    .duration_since(connection.time)
+                    .unwrap()
+                    .as_millis() as i64,
+            };
+            pong.parse()
+        }
+        OnlinePackets::FramePacket(_v) => {
+            println!("Condition should never be met.");
+            Vec::new()
+        }
+        _ => Vec::new(), // TODO: Throw an UnknownPacket here rather than sending an empty binary stream
+    }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,9 +1,7 @@
-use crate::conn::{Connection, ConnectionState, RecievePacketFn};
+use crate::conn::{Connection, ConnectionState};
 use crate::util::{from_tokenized, tokenize_addr};
 use crate::Motd;
-use binary_utils::*;
 use std::collections::HashMap;
-use std::hash::Hash;
 use std::net::UdpSocket;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -42,13 +40,38 @@ pub enum RakNetEvent {
     /// 2. The reason for disconnect.
     Disconnect(String, String),
     /// When a connection is sent a motd.
+    /// You should return a Motd here if you want to change the MOTD.
     ///
     /// **Tuple Values**:
     /// 1. The parsed `ip:port` address of the connection.
-    MotdGeneration(String),
+    MotdGeneration(String, Motd),
+    /// When a game packet is recieved.
+    ///
+    /// **Tuple Values**:
+    /// 1. The parsed `ip:port` address of the connection.
+    /// 2. The packet `Vec<u8>` recieved from the connection.
+    GamePacket(String, Vec<u8>),
 }
 
-pub type RakEventListenerFn = dyn FnMut(&RakNetEvent) + Send + Sync;
+pub enum RakResult {
+    /// Update the Motd for that specific client.
+    ///
+    /// **Tuple Values**:
+    /// 1. The `Motd` for the current connection.
+    Motd(Motd),
+    /// Force the raknet server to invoke `panic!`.
+    ///
+    /// **Tuple Values**:
+    /// 1. The message passed to `panic!`
+    Error(String),
+    /// Force the current client to disconnect.
+    /// This does **NOT** emit a disonnect event.
+    /// **Tuple Values**:
+    /// 1. The reason for disconnect (if any).
+    Disconnect(String),
+}
+
+pub type RakEventListenerFn = dyn FnMut(&RakNetEvent) -> Option<RakResult> + Send + Sync;
 
 pub struct RakNetServer {
     pub address: String,
@@ -75,7 +98,10 @@ impl RakNetServer {
 
     /// Sends a stream to the specified address.
     /// Instant skips the tick and forcefully sends the packet to the client.
-    pub fn send_stream(&mut self, address: String, stream: Vec<u8>, instant: bool) {
+    /// Params:
+    /// - instant(true) -> Skips entire fragmentation and immediately sequences the
+    ///   buffer into a stream.
+    pub fn send(&mut self, address: String, stream: Vec<u8>, instant: bool) {
         let clients = self.connections.lock();
         match clients.unwrap().get_mut(&address) {
             Some(c) => c.send(stream, instant),
@@ -87,7 +113,6 @@ impl RakNetServer {
     /// Returns two thread handles, for both the send and recieving threads.
     pub fn start(
         &mut self,
-        receiver: Arc<RecievePacketFn>,
         mut event_dispatch: Box<RakEventListenerFn>,
     ) -> (thread::JoinHandle<()>, thread::JoinHandle<()>) {
         let socket = UdpSocket::bind(self.address.clone());
@@ -115,12 +140,7 @@ impl RakNetServer {
                     // connection doesn't exist, make it
                     sclients.insert(
                         tokenize_addr(remote),
-                        Connection::new(
-                            remote,
-                            *server_time.as_ref(),
-                            Arc::clone(&receiver),
-                            Arc::clone(&motd),
-                        ),
+                        Connection::new(remote, *server_time.as_ref(), Arc::clone(&motd)),
                     );
                 }
 
@@ -141,7 +161,23 @@ impl RakNetServer {
                     client.do_tick();
                     // emit events if there is a listener for the
                     for event in client.event_dispatch.iter() {
-                        event_dispatch(event);
+                        if let Some(result) = event_dispatch(event) {
+                            match result {
+                                RakResult::Motd(_v) => {
+                                    // we don't really support changing
+                                    // client MOTD at the moment...
+                                    // so we don't do anything for this.
+                                }
+                                RakResult::Error(v) => {
+                                    // Calling error forces an error to raise.
+                                    panic!("{}", v);
+                                }
+                                RakResult::Disconnect(_) => {
+                                    client.state = ConnectionState::Offline; // simple hack
+                                    break;
+                                }
+                            }
+                        }
                     }
 
                     client.event_dispatch.clear();

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,47 +1,46 @@
 use crate::MAGIC;
 use binary_utils::*;
-use std::net::{Ipv4Addr, SocketAddr, ToSocketAddrs};
-use std::io::Cursor;
+use std::net::{SocketAddr, ToSocketAddrs};
 
 // Raknet utilities
 pub trait IPacketStreamWrite {
-     fn write_magic(&mut self);
+    fn write_magic(&mut self);
 
-     fn write_address(&mut self, add: SocketAddr);
+    fn write_address(&mut self, add: SocketAddr);
 }
 
 pub trait IPacketStreamRead {
-     fn read_magic(&mut self) -> Vec<u8>;
+    fn read_magic(&mut self) -> Vec<u8>;
 
-     fn read_address(&mut self) -> SocketAddr;
+    fn read_address(&mut self) -> SocketAddr;
 }
 
 #[derive(Debug)]
 pub struct Magic(pub Vec<u8>);
 
 impl Magic {
-     pub fn new() -> Self {
-          Self(MAGIC.to_vec())
-     }
+    pub fn new() -> Self {
+        Self(MAGIC.to_vec())
+    }
 }
 
 impl Streamable for Magic {
-     fn parse(&self) -> Vec<u8> {
-         MAGIC.to_vec()
-     }
+    fn parse(&self) -> Vec<u8> {
+        MAGIC.to_vec()
+    }
 
-     fn compose(source: &[u8], position: &mut usize) -> Self {
-         // magic is 16 bytes
-         let pos = *position + (16 as usize);
-         let magic = &source[*position..pos];
-         *position += 16;
+    fn compose(source: &[u8], position: &mut usize) -> Self {
+        // magic is 16 bytes
+        let pos = *position + (16 as usize);
+        let magic = &source[*position..pos];
+        *position += 16;
 
-         if magic.to_vec() != MAGIC.to_vec() {
-              panic!("Could not construct magic from malformed bytes.")
-         } else {
-              Self(magic.to_vec())
-         }
-     }
+        if magic.to_vec() != MAGIC.to_vec() {
+            panic!("Could not construct magic from malformed bytes.")
+        } else {
+            Self(magic.to_vec())
+        }
+    }
 }
 
 // impl IPacketStreamWrite for BinaryStream {
@@ -85,13 +84,15 @@ impl Streamable for Magic {
 // }
 
 pub fn tokenize_addr(remote: SocketAddr) -> String {
-     let mut address = remote.ip().to_string();
-     address.push_str(":");
-     address.push_str(remote.port().to_string().as_str());
-     return address;
+    let mut address = remote.ip().to_string();
+    address.push_str(":");
+    address.push_str(remote.port().to_string().as_str());
+    return address;
 }
 
 pub fn from_tokenized(remote: String) -> SocketAddr {
-     let mut parsed = remote.to_socket_addrs().expect("Could not parse remote address.");
-     SocketAddr::from(parsed.next().unwrap())
+    let mut parsed = remote
+        .to_socket_addrs()
+        .expect("Could not parse remote address.");
+    SocketAddr::from(parsed.next().unwrap())
 }

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -1,7 +1,9 @@
 use rakrs::RakNetServer;
 use rakrs::conn::{Connection};
 use rakrs::Motd;
+use rakrs::RakResult;
 use rakrs::RakNetEvent;
+use rakrs::raknet_start;
 use binary_utils::*;
 use std::sync::{Arc};
 
@@ -16,19 +18,24 @@ fn main() {
           version: "1.18.9".to_owned(),
           server_id: 2747994720109207718 as i64
      });
-     let threads = server.start(Arc::new(|_con: &mut Connection, pk: &mut Vec<u8>| {
-               println!("Got game packet.");
-          }), Box::new(|ev: &RakNetEvent| {
+     let threads = raknet_start!(server, move |ev: &RakNetEvent| {
           match ev.clone() {
                RakNetEvent::Disconnect(address, reason) => {
                     println!("{} disconnected due to: {}", address, reason);
+                    None
                },
                RakNetEvent::ConnectionCreated(address) => {
                     println!("{} has joined the server", address);
-               }
-               _ => return
+                    None
+               },
+               RakNetEvent::GamePacket(address, packet) => {
+                    println!("{} send a game packet!!", address);
+                    // serv.send(address, vec![16], true);
+                    Some(RakResult::Disconnect("U suck!".into()))
+               },
+               _ => None
           }
-     }));
+     });
      threads.0.join();
      threads.1.join();
      println!("Hi I am running concurrently.");


### PR DESCRIPTION
This PR adds a better events api, eg, instead of wrapping a load of functions into `RakNetServer.start` you can now use:
```rs
let mut server = RakNetServer::new("0.0.0.0:19132".into());
let threads = raknet_start!(server, move |event: &RakNetEvent| {
	// code
});
```