### PR TITLE
Implement std::fmt::Display and std::error::Error for exposed error types

### DIFF
--- a/src/connection/queue/mod.rs
+++ b/src/connection/queue/mod.rs
@@ -414,14 +414,18 @@ pub enum FragmentQueueError {
 
 impl std::fmt::Display for FragmentQueueError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", match self {
-            FragmentQueueError::FrameExists => "Frame already exists",
-            FragmentQueueError::FrameNotFragmented => "Frame is not fragmented",
-            FragmentQueueError::DoesNotNeedSplit => "Frame does not need to be split",
-            FragmentQueueError::FragmentInvalid => "Fragment is invalid",
-            FragmentQueueError::FragmentsMissing => "Fragments are missing",
-            FragmentQueueError::FrameIndexOutOfBounds => "Frame index is out of bounds",
-        })
+        write!(
+            f,
+            "{}",
+            match self {
+                FragmentQueueError::FrameExists => "Frame already exists",
+                FragmentQueueError::FrameNotFragmented => "Frame is not fragmented",
+                FragmentQueueError::DoesNotNeedSplit => "Frame does not need to be split",
+                FragmentQueueError::FragmentInvalid => "Fragment is invalid",
+                FragmentQueueError::FragmentsMissing => "Fragments are missing",
+                FragmentQueueError::FrameIndexOutOfBounds => "Frame index is out of bounds",
+            }
+        )
     }
 }
 

--- a/src/connection/queue/mod.rs
+++ b/src/connection/queue/mod.rs
@@ -411,3 +411,18 @@ pub enum FragmentQueueError {
     FragmentsMissing,
     FrameIndexOutOfBounds,
 }
+
+impl std::fmt::Display for FragmentQueueError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            FragmentQueueError::FrameExists => "Frame already exists",
+            FragmentQueueError::FrameNotFragmented => "Frame is not fragmented",
+            FragmentQueueError::DoesNotNeedSplit => "Frame does not need to be split",
+            FragmentQueueError::FragmentInvalid => "Fragment is invalid",
+            FragmentQueueError::FragmentsMissing => "Fragments are missing",
+            FragmentQueueError::FrameIndexOutOfBounds => "Frame index is out of bounds",
+        })
+    }
+}
+
+impl std::error::Error for FragmentQueueError {}

--- a/src/connection/queue/send.rs
+++ b/src/connection/queue/send.rs
@@ -34,10 +34,10 @@ pub enum SendQueueError {
 impl std::fmt::Display for SendQueueError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", match self {
-            SendQueueError::PacketTooLarge => "Packet too large",
-            SendQueueError::ParseError => "Parse error",
+            SendQueueError::PacketTooLarge => "Packet too large".to_string(),
+            SendQueueError::ParseError => "Parse error".to_string(),
             SendQueueError::FragmentError(e) => format!("Fragment error: {}", e),
-            SendQueueError::SendError => "Send error",
+            SendQueueError::SendError => "Send error".to_string(),
         })
     }
 }

--- a/src/connection/queue/send.rs
+++ b/src/connection/queue/send.rs
@@ -33,16 +33,20 @@ pub enum SendQueueError {
 
 impl std::fmt::Display for SendQueueError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", match self {
-            SendQueueError::PacketTooLarge => "Packet too large".to_string(),
-            SendQueueError::ParseError => "Parse error".to_string(),
-            SendQueueError::FragmentError(e) => format!("Fragment error: {}", e),
-            SendQueueError::SendError => "Send error".to_string(),
-        })
+        write!(
+            f,
+            "{}",
+            match self {
+                SendQueueError::PacketTooLarge => "Packet too large".to_string(),
+                SendQueueError::ParseError => "Parse error".to_string(),
+                SendQueueError::FragmentError(e) => format!("Fragment error: {}", e),
+                SendQueueError::SendError => "Send error".to_string(),
+            }
+        )
     }
 }
 
-impl std::error::Error for SendQueueError { }
+impl std::error::Error for SendQueueError {}
 
 /// This queue is used to prioritize packets being sent out
 /// Packets that are old, are either dropped or requested again.

--- a/src/connection/queue/send.rs
+++ b/src/connection/queue/send.rs
@@ -31,6 +31,19 @@ pub enum SendQueueError {
     SendError,
 }
 
+impl std::fmt::Display for SendQueueError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            SendQueueError::PacketTooLarge => "Packet too large",
+            SendQueueError::ParseError => "Parse error",
+            SendQueueError::FragmentError(e) => format!("Fragment error: {}", e),
+            SendQueueError::SendError => "Send error",
+        })
+    }
+}
+
+impl std::error::Error for SendQueueError {
+
 /// This queue is used to prioritize packets being sent out
 /// Packets that are old, are either dropped or requested again.
 /// You can define this behavior with the `timeout` property.

--- a/src/connection/queue/send.rs
+++ b/src/connection/queue/send.rs
@@ -42,7 +42,7 @@ impl std::fmt::Display for SendQueueError {
     }
 }
 
-impl std::error::Error for SendQueueError {
+impl std::error::Error for SendQueueError { }
 
 /// This queue is used to prioritize packets being sent out
 /// Packets that are old, are either dropped or requested again.

--- a/src/error/client.rs
+++ b/src/error/client.rs
@@ -25,3 +25,22 @@ pub enum ClientError {
     /// The client failed to process a packet you sent.
     SendQueueError(SendQueueError),
 }
+
+
+impl std::fmt::Display for ClientError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            ClientError::AddrBindErr => "Failed to bind to address",
+            ClientError::AlreadyOnline => "Already online",
+            ClientError::NotListening => "Not listening",
+            ClientError::Unavailable => "Unavailable",
+            ClientError::IncompatibleProtocolVersion => "Incompatible protocol version",
+            ClientError::Killed => "Killed",
+            ClientError::Reset => "Reset",
+            ClientError::ServerOffline => "Server offline",
+            ClientError::SendQueueError(e) => return e.fmt(f),
+        })
+    }
+}
+
+impl std::error::Error for ClientError {}

--- a/src/error/client.rs
+++ b/src/error/client.rs
@@ -1,4 +1,4 @@
-//! Client errors are errors that can occur when using the [`Client`](crate::client::Client) api.
+s//! Client errors are errors that can occur when using the [`Client`](crate::client::Client) api.
 use crate::connection::queue::SendQueueError;
 
 /// These are errors that can occur when using the [`Client`](crate::client::Client) api.
@@ -28,7 +28,7 @@ pub enum ClientError {
 
 
 impl std::fmt::Display for ClientError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", match self {
             ClientError::AddrBindErr => "Failed to bind to address",
             ClientError::AlreadyOnline => "Already online",

--- a/src/error/client.rs
+++ b/src/error/client.rs
@@ -26,20 +26,23 @@ pub enum ClientError {
     SendQueueError(SendQueueError),
 }
 
-
 impl std::fmt::Display for ClientError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", match self {
-            ClientError::AddrBindErr => "Failed to bind to address",
-            ClientError::AlreadyOnline => "Already online",
-            ClientError::NotListening => "Not listening",
-            ClientError::Unavailable => "Unavailable",
-            ClientError::IncompatibleProtocolVersion => "Incompatible protocol version",
-            ClientError::Killed => "Killed",
-            ClientError::Reset => "Reset",
-            ClientError::ServerOffline => "Server offline",
-            ClientError::SendQueueError(e) => return e.fmt(f),
-        })
+        write!(
+            f,
+            "{}",
+            match self {
+                ClientError::AddrBindErr => "Failed to bind to address",
+                ClientError::AlreadyOnline => "Already online",
+                ClientError::NotListening => "Not listening",
+                ClientError::Unavailable => "Unavailable",
+                ClientError::IncompatibleProtocolVersion => "Incompatible protocol version",
+                ClientError::Killed => "Killed",
+                ClientError::Reset => "Reset",
+                ClientError::ServerOffline => "Server offline",
+                ClientError::SendQueueError(e) => return e.fmt(f),
+            }
+        )
     }
 }
 

--- a/src/error/client.rs
+++ b/src/error/client.rs
@@ -1,4 +1,4 @@
-s//! Client errors are errors that can occur when using the [`Client`](crate::client::Client) api.
+//! Client errors are errors that can occur when using the [`Client`](crate::client::Client) api.
 use crate::connection::queue::SendQueueError;
 
 /// These are errors that can occur when using the [`Client`](crate::client::Client) api.

--- a/src/error/connection.rs
+++ b/src/error/connection.rs
@@ -11,3 +11,14 @@ pub enum ConnectionError {
     /// The connection has been closed by the peer.
     EventDispatchError,
 }
+
+impl std::fmt::Display for ConnectionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            ConnectionError::Closed => "Connection closed",
+            ConnectionError::EventDispatchError => "Event dispatch error",
+        })
+    }
+}
+
+impl std::error::Error for ConnectionError {}

--- a/src/error/connection.rs
+++ b/src/error/connection.rs
@@ -14,10 +14,14 @@ pub enum ConnectionError {
 
 impl std::fmt::Display for ConnectionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", match self {
-            ConnectionError::Closed => "Connection closed",
-            ConnectionError::EventDispatchError => "Event dispatch error",
-        })
+        write!(
+            f,
+            "{}",
+            match self {
+                ConnectionError::Closed => "Connection closed",
+                ConnectionError::EventDispatchError => "Event dispatch error",
+            }
+        )
     }
 }
 

--- a/src/error/connection.rs
+++ b/src/error/connection.rs
@@ -13,7 +13,7 @@ pub enum ConnectionError {
 }
 
 impl std::fmt::Display for ConnectionError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", match self {
             ConnectionError::Closed => "Connection closed",
             ConnectionError::EventDispatchError => "Event dispatch error",

--- a/src/error/server.rs
+++ b/src/error/server.rs
@@ -13,3 +13,17 @@ pub enum ServerError {
     /// The server has been closed, and can not be used again.
     Reset,
 }
+
+impl std::fmt::Display for ServerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            ServerError::AddrBindErr => "Unable to bind to address",
+            ServerError::AlreadyOnline => "Already online",
+            ServerError::NotListening => "Not listening",
+            ServerError::Killed => "Killed",
+            ServerError::Reset => "Reset",
+        })
+    }
+}
+
+impl std::error::Error for ServerError {}

--- a/src/error/server.rs
+++ b/src/error/server.rs
@@ -16,13 +16,17 @@ pub enum ServerError {
 
 impl std::fmt::Display for ServerError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", match self {
-            ServerError::AddrBindErr => "Unable to bind to address",
-            ServerError::AlreadyOnline => "Already online",
-            ServerError::NotListening => "Not listening",
-            ServerError::Killed => "Killed",
-            ServerError::Reset => "Reset",
-        })
+        write!(
+            f,
+            "{}",
+            match self {
+                ServerError::AddrBindErr => "Unable to bind to address",
+                ServerError::AlreadyOnline => "Already online",
+                ServerError::NotListening => "Not listening",
+                ServerError::Killed => "Killed",
+                ServerError::Reset => "Reset",
+            }
+        )
     }
 }
 


### PR DESCRIPTION
This change allows users of raknet to use eyre and anyhow to propagate the errors upwards using the ? operator:

```
async fn smth() -> eyre::Result<()> {
    // These work now:
    let mut listener = Listener::bind("0.0.0.0:1234").await?;
    listener.start().await?;
    
    Ok(())
}
```